### PR TITLE
added an argument to specify number of IQ pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-07-14
+### Added
+- Optional `num_IQ_pairs` argument to `declare_qua_variables`.  
+
 ## [0.1.0] - 2025-05-07
 ### Added
 - Architecture components for Flux Tunable Transmons.
@@ -12,5 +16,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Builder functions for the general QUAM wiring.
 - Builder functions for Transmons.
 
-[Unreleased]: https://github.com/qua-platform/quam-builder/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/qua-platform/quam-builder/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/qua-platform/quam-builder/releases/tag/v0.1.1
 [0.1.0]: https://github.com/qua-platform/quam-builder/releases/tag/v0.1.0

--- a/quam_builder/architecture/superconducting/qpu/base_quam.py
+++ b/quam_builder/architecture/superconducting/qpu/base_quam.py
@@ -148,6 +148,10 @@ class BaseQuam(QuamRoot):
     ]:
         """Macro to declare the necessary QUA variables for all qubits.
 
+        Args:
+            num_IQ_pairs (Optional[int]): Number of IQ pairs (I and Q variables) to declare.
+                If None, it defaults to the number of qubits in `self.qubits`.
+
         Returns:
             tuple: A tuple containing lists of QUA variables and streams.
         """

--- a/quam_builder/architecture/superconducting/qpu/base_quam.py
+++ b/quam_builder/architecture/superconducting/qpu/base_quam.py
@@ -137,6 +137,7 @@ class BaseQuam(QuamRoot):
 
     def declare_qua_variables(
         self,
+        num_IQ_pairs: Optional[int] = None,
     ) -> tuple[
         list[QuaVariable],
         list[StreamType],
@@ -150,12 +151,15 @@ class BaseQuam(QuamRoot):
         Returns:
             tuple: A tuple containing lists of QUA variables and streams.
         """
+        if num_IQ_pairs is None:
+            num_IQ_pairs = len(self.qubits)
+
         n = declare(int)
         n_st = declare_stream()
-        I = [declare(fixed) for _ in range(len(self.qubits))]
-        Q = [declare(fixed) for _ in range(len(self.qubits))]
-        I_st = [declare_stream() for _ in range(len(self.qubits))]
-        Q_st = [declare_stream() for _ in range(len(self.qubits))]
+        I = [declare(fixed) for _ in range(num_IQ_pairs)]
+        Q = [declare(fixed) for _ in range(num_IQ_pairs)]
+        I_st = [declare_stream() for _ in range(num_IQ_pairs)]
+        Q_st = [declare_stream() for _ in range(num_IQ_pairs)]
         return I, I_st, Q, Q_st, n, n_st
 
     def initialize_qpu(self, **kwargs):


### PR DESCRIPTION
Added an argument to specify number of IQ pairs.

The default is `None` and acts as before (generating `len(self.qubits)` of IQ pairs.

This is useful when one wants to get IQ pairs for qubit_pairs, which, in general, have different number from `self.qubits`.

An example usage:

Generating `num_qubit_pairs` of IQ pairs for control and target qubits, respectively.
```
        I_c, I_c_st, Q_c, Q_c_st, n, n_st = node.machine.declare_qua_variables(num_IQ_pairs=num_qubit_pairs)
        I_t, I_t_st, Q_t, Q_t_st, _, _ = node.machine.declare_qua_variables(num_IQ_pairs=num_qubit_pairs)
```

