### PR TITLE
Fix: Add pytest and uv.prerelease=allow to pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Changed
+- Fixed dev dependencies and added tool.uv.prerelease=allow to the pyproject.toml file.
 
 ## [0.1.2] - 2025-08-06
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,7 @@ description = "A Python tool designed to programmatically construct QUAM (Quantu
 readme = "README.md"
 authors = [{ name = "Theo Laudat", email = "theo@quantum-machines.co" }]
 requires-python = ">=3.9,<3.13"
-dependencies = [
-    "qualang-tools>=0.19.0",
-    "quam>=0.4.0",
-]
+dependencies = ["qualang-tools>=0.19.0", "quam>=0.4.0"]
 
 [build-system]
 requires = ["hatchling"]
@@ -19,3 +16,11 @@ build-backend = "hatchling.build"
 
 [tool.hatch.metadata]
 allow-direct-references = true
+
+[tool.uv]
+prerelease = "allow"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.1",
+]


### PR DESCRIPTION
This pull request makes minor updates to the `pyproject.toml` configuration, primarily improving dependency formatting and adding new development tooling options.

Dependency management improvements:

* Reformatted the `dependencies` list to a single line for better readability in `pyproject.toml`.

Development tooling additions:

* Added a `[dependency-groups]` section with a `dev` group specifying `pytest` as a development dependency.
* Introduced a `[tool.uv]` section to allow prerelease dependencies.