### PR TITLE
Add digital marker names

### DIFF
--- a/quam_builder/builder/qop_connectivity/get_digital_outputs.py
+++ b/quam_builder/builder/qop_connectivity/get_digital_outputs.py
@@ -18,13 +18,13 @@ def get_digital_outputs(
     digital_outputs = dict()
     for i, item in enumerate([port for port in ports if "digital_output" in port]):
         if digital_marker_name == "octave_switch":
-            if type(DigitalOutputChannel(opx_output=f"{wiring_path}/{item}").opx_output) == FEMDigitalOutputPort:
+            if isinstance(DigitalOutputChannel(opx_output=f"{wiring_path}/{item}").opx_output, FEMDigitalOutputPort):
                 digital_outputs[f"{digital_marker_name}_{i}"] = DigitalOutputChannel(
                     opx_output=f"{wiring_path}/{item}",
                     delay=14,  # 14ns for QOP333 and above
                     buffer=13,  # 13ns for QOP333 and above
                 )
-            elif type(DigitalOutputChannel(opx_output=f"{wiring_path}/{item}").opx_output) == OPXPlusDigitalOutputPort:
+            elif isinstance(DigitalOutputChannel(opx_output=f"{wiring_path}/{item}").opx_output, OPXPlusDigitalOutputPort):
                 digital_outputs[f"{digital_marker_name}_{i}"] = DigitalOutputChannel(
                     opx_output=f"{wiring_path}/{item}",
                     delay=57,  # 57ns for QOP222 and above


### PR DESCRIPTION
Add the possibility to set the name of the digital markers, as it was previously hardcoded to "octave_switch".
I also customized the delay and buffer based on the QOP.