### PR TITLE
QDAC2 wiring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [{ name = "Theo Laudat", email = "theo@quantum-machines.co" }]
 requires-python = ">=3.9,<3.13"
 dependencies = [
-    "qualang-tools @ git+https://github.com/qua-platform/py-qua-tools.git@main",
+    "qualang-tools>=0.22.0",
     "quam>=0.4.0",
     "qm-qua>=1.2.2",
     "xarray>=2024.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ readme = "README.md"
 authors = [{ name = "Theo Laudat", email = "theo@quantum-machines.co" }]
 requires-python = ">=3.9,<3.13"
 dependencies = [
-    "qualang-tools @ git+https://github.com/qua-platform/py-qua-tools.git@release/nightly",    "quam>=0.4.0",
+    "qualang-tools>=0.22.0",
+    "quam>=0.4.0",
     "qm-qua>=1.2.2",
     "xarray>=2023.12.0",
     "qcodes-contrib-drivers>=0.22.0",

--- a/quam_builder/architecture/quantum_dots/components/pulses.py
+++ b/quam_builder/architecture/quantum_dots/components/pulses.py
@@ -49,7 +49,7 @@ class ScalableGaussianPulse(GaussianPulse):
 
     def waveform_function(self):
         sigma = self.length * self.sigma_ratio
-        if ~isinstance(self.sigma, str):
+        if not isinstance(self.get_raw_value("sigma"), str):
             self.sigma = sigma
         t = np.arange(self.length, dtype=int)
         center = (self.length - 1) / 2
@@ -169,7 +169,7 @@ class ScalableHermitePulse(Pulse):
 
     def waveform_function(self):
         sigma = self.length * self.sigma_ratio
-        if ~isinstance(self.sigma, str):
+        if not isinstance(self.get_raw_value("sigma"), str):
             self.sigma = sigma
         t = np.arange(self.length, dtype=float)
         center = (self.length - 1) / 2.0
@@ -221,7 +221,7 @@ class ScalableDragPulse(Pulse):
 
     def waveform_function(self):
         sigma = self.length * self.sigma_ratio
-        if ~isinstance(self.sigma, str):
+        if not isinstance(self.get_raw_value("sigma"), str):
             self.sigma = sigma
         t = np.arange(self.length, dtype=float)
         center = (self.length - 1) / 2.0

--- a/quam_builder/architecture/quantum_dots/components/pulses.py
+++ b/quam_builder/architecture/quantum_dots/components/pulses.py
@@ -41,13 +41,14 @@ class ScalableGaussianPulse(GaussianPulse):
     sigma: float = None
     sigma_ratio: float = DEFAULTS.xy_pulse.sigma_ratio
 
-    def __post_init__(self):
-        super().__post_init__()
-        if not isinstance(self.length, str) and not isinstance(self.sigma_ratio, str):
-            self.sigma = self.length * self.sigma_ratio
+    # TODO removed to avoid quam warnings
+    # def __post_init__(self):
+    #     super().__post_init__()
+    #     if not isinstance(self.length, str) and not isinstance(self.sigma_ratio, str):
+    #         self.sigma = self.length * self.sigma_ratio
 
     def waveform_function(self):
-        sigma = self.length * self.sigma_ratio
+        self.sigma = sigma = self.length * self.sigma_ratio
         t = np.arange(self.length, dtype=int)
         center = (self.length - 1) / 2
         waveform = self.amplitude * np.exp(-((t - center) ** 2) / (2 * sigma**2))
@@ -158,13 +159,14 @@ class ScalableHermitePulse(Pulse):
     hermite_coeff: float = 0.5
     axis_angle: float = None
 
-    def __post_init__(self):
-        super().__post_init__()
-        if not isinstance(self.length, str) and not isinstance(self.sigma_ratio, str):
-            self.sigma = self.length * self.sigma_ratio
+    # TODO removed to avoid quam warnings
+    # def __post_init__(self):
+    #     super().__post_init__()
+    #     if not isinstance(self.length, str) and not isinstance(self.sigma_ratio, str):
+    #         self.sigma = self.length * self.sigma_ratio
 
     def waveform_function(self):
-        sigma = self.length * self.sigma_ratio
+        self.sigma = sigma = self.length * self.sigma_ratio
         t = np.arange(self.length, dtype=float)
         center = (self.length - 1) / 2.0
         x = (t - center) / sigma
@@ -207,13 +209,14 @@ class ScalableDragPulse(Pulse):
     drag_coefficient: float = 0.5
     axis_angle: float = None
 
-    def __post_init__(self):
-        super().__post_init__()
-        if not isinstance(self.length, str) and not isinstance(self.sigma_ratio, str):
-            self.sigma = self.length * self.sigma_ratio
+    # TODO removed to avoid quam warnings
+    # def __post_init__(self):
+    #     super().__post_init__()
+    #     if not isinstance(self.length, str) and not isinstance(self.sigma_ratio, str):
+    #         self.sigma = self.length * self.sigma_ratio
 
     def waveform_function(self):
-        sigma = self.length * self.sigma_ratio
+        self.sigma = sigma = self.length * self.sigma_ratio
         t = np.arange(self.length, dtype=float)
         center = (self.length - 1) / 2.0
         x = (t - center) / sigma

--- a/quam_builder/architecture/quantum_dots/components/pulses.py
+++ b/quam_builder/architecture/quantum_dots/components/pulses.py
@@ -48,7 +48,9 @@ class ScalableGaussianPulse(GaussianPulse):
     #         self.sigma = self.length * self.sigma_ratio
 
     def waveform_function(self):
-        self.sigma = sigma = self.length * self.sigma_ratio
+        sigma = self.length * self.sigma_ratio
+        if ~isinstance(self.sigma, str):
+            self.sigma = sigma
         t = np.arange(self.length, dtype=int)
         center = (self.length - 1) / 2
         waveform = self.amplitude * np.exp(-((t - center) ** 2) / (2 * sigma**2))
@@ -166,7 +168,9 @@ class ScalableHermitePulse(Pulse):
     #         self.sigma = self.length * self.sigma_ratio
 
     def waveform_function(self):
-        self.sigma = sigma = self.length * self.sigma_ratio
+        sigma = self.length * self.sigma_ratio
+        if ~isinstance(self.sigma, str):
+            self.sigma = sigma
         t = np.arange(self.length, dtype=float)
         center = (self.length - 1) / 2.0
         x = (t - center) / sigma
@@ -216,7 +220,9 @@ class ScalableDragPulse(Pulse):
     #         self.sigma = self.length * self.sigma_ratio
 
     def waveform_function(self):
-        self.sigma = sigma = self.length * self.sigma_ratio
+        sigma = self.length * self.sigma_ratio
+        if ~isinstance(self.sigma, str):
+            self.sigma = sigma
         t = np.arange(self.length, dtype=float)
         center = (self.length - 1) / 2.0
         x = (t - center) / sigma

--- a/quam_builder/architecture/quantum_dots/components/quantum_dot_pair.py
+++ b/quam_builder/architecture/quantum_dots/components/quantum_dot_pair.py
@@ -47,17 +47,17 @@ class QuantumDotPair(VoltageMacroMixin):  # pylint: disable=too-many-ancestors
 
     def __post_init__(self):
         super().__post_init__()
-        if isinstance(self.quantum_dots[0], str):
-            return
-        if len(self.quantum_dots) != 2:
-            raise ValueError(
-                f"Number of QuantumDots in QuantumDotPair must be 2. Received {len(self.quantum_dots)} QuantumDots"
-            )
-        if self.id is None:
-            self.id = f"{self.quantum_dots[0].id}_{self.quantum_dots[1].id}"
-
-        if self.quantum_dots[0].voltage_sequence is not self.quantum_dots[1].voltage_sequence:
-            raise ValueError("Quantum Dots not part of same VoltageSequence")
+        # if isinstance(self.quantum_dots[0], str):
+        #     return
+        # if len(self.quantum_dots) != 2:
+        #     raise ValueError(
+        #         f"Number of QuantumDots in QuantumDotPair must be 2. Received {len(self.quantum_dots)} QuantumDots"
+        #     )
+        # if self.id is None:
+        #     self.id = f"{self.quantum_dots[0].id}_{self.quantum_dots[1].id}"
+        #
+        # if self.quantum_dots[0].voltage_sequence is not self.quantum_dots[1].voltage_sequence:
+        #     raise ValueError("Quantum Dots not part of same VoltageSequence")
 
         self.detuning_axis_name = f"{self.id}_epsilon"
 

--- a/quam_builder/architecture/quantum_dots/components/quantum_dot_pair.py
+++ b/quam_builder/architecture/quantum_dots/components/quantum_dot_pair.py
@@ -9,6 +9,7 @@ from .sensor_dot import SensorDot
 from .barrier_gate import BarrierGate
 from .mixins import VoltageMacroMixin
 from .voltage_gate import VoltageGate
+from .virtual_gate_set import VirtualGateSet
 
 if TYPE_CHECKING:
     from quam_builder.architecture.quantum_dots.qpu import BaseQuamQD
@@ -66,6 +67,10 @@ class QuantumDotPair(VoltageMacroMixin):  # pylint: disable=too-many-ancestors
         return self.barrier_gate.physical_channel
 
     @property
+    def gate_set(self) -> VirtualGateSet:
+        return self.quantum_dots[0].machine._get_virtual_gate_set(self.quantum_dots[0].physical_channel)
+
+    @property
     def voltage_sequence(self) -> VoltageSequence:
         return self.quantum_dots[0].voltage_sequence
 
@@ -91,7 +96,7 @@ class QuantumDotPair(VoltageMacroMixin):  # pylint: disable=too-many-ancestors
         # Ensure that the detuning axis name held in object is consistent
         self.detuning_axis_name = detuning_axis_name
 
-        virtual_gate_set = self.voltage_sequence.gate_set
+        virtual_gate_set = self.gate_set
 
         # Should be the correct virtual axes in the first layer of the VirtualGateSet
         target_gates = [qd.id for qd in self.quantum_dots]

--- a/quam_builder/architecture/quantum_dots/components/quantum_dot_pair.py
+++ b/quam_builder/architecture/quantum_dots/components/quantum_dot_pair.py
@@ -49,22 +49,17 @@ class QuantumDotPair(VoltageMacroMixin):  # pylint: disable=too-many-ancestors
 
     def __post_init__(self):
         super().__post_init__()
-        if isinstance(self.quantum_dots[0], str) or isinstance(
-            self.quantum_dots[1], str
-        ):
-            return
-        if len(self.quantum_dots) != 2:
-            raise ValueError(
-                f"Number of QuantumDots in QuantumDotPair must be 2. Received {len(self.quantum_dots)} QuantumDots"
-            )
-        if self.id is None:
-            self.id = f"{self.quantum_dots[0].id}_{self.quantum_dots[1].id}"
-
-        if (
-            self.quantum_dots[0].voltage_sequence
-            is not self.quantum_dots[1].voltage_sequence
-        ):
-            raise ValueError("Quantum Dots not part of same VoltageSequence")
+        # if isinstance(self.quantum_dots[0], str):
+        #     return
+        # if len(self.quantum_dots) != 2:
+        #     raise ValueError(
+        #         f"Number of QuantumDots in QuantumDotPair must be 2. Received {len(self.quantum_dots)} QuantumDots"
+        #     )
+        # if self.id is None:
+        #     self.id = f"{self.quantum_dots[0].id}_{self.quantum_dots[1].id}"
+        #
+        # if self.quantum_dots[0].voltage_sequence is not self.quantum_dots[1].voltage_sequence:
+        #     raise ValueError("Quantum Dots not part of same VoltageSequence")
 
         self.detuning_axis_name = f"{self.id}_epsilon"
 

--- a/quam_builder/architecture/quantum_dots/components/quantum_dot_pair.py
+++ b/quam_builder/architecture/quantum_dots/components/quantum_dot_pair.py
@@ -11,6 +11,7 @@ from .sensor_dot import SensorDot
 from .barrier_gate import BarrierGate
 from .mixins import VoltageMacroMixin
 from .voltage_gate import VoltageGate
+from .virtual_gate_set import VirtualGateSet
 
 if TYPE_CHECKING:
     from quam_builder.architecture.quantum_dots.qpu import BaseQuamQD
@@ -68,6 +69,10 @@ class QuantumDotPair(VoltageMacroMixin):  # pylint: disable=too-many-ancestors
         return self.barrier_gate.physical_channel
 
     @property
+    def gate_set(self) -> VirtualGateSet:
+        return self.quantum_dots[0].machine._get_virtual_gate_set(self.quantum_dots[0].physical_channel)
+
+    @property
     def voltage_sequence(self) -> VoltageSequence:
         return self.quantum_dots[0].voltage_sequence
 
@@ -93,7 +98,7 @@ class QuantumDotPair(VoltageMacroMixin):  # pylint: disable=too-many-ancestors
         # Ensure that the detuning axis name held in object is consistent
         self.detuning_axis_name = detuning_axis_name
 
-        virtual_gate_set = self.voltage_sequence.gate_set
+        virtual_gate_set = self.gate_set
 
         # Should be the correct virtual axes in the first layer of the VirtualGateSet
         target_gates = [qd.id for qd in self.quantum_dots]

--- a/quam_builder/architecture/quantum_dots/components/readout_resonator.py
+++ b/quam_builder/architecture/quantum_dots/components/readout_resonator.py
@@ -55,9 +55,10 @@ class ReadoutResonatorBase:
 class ReadoutResonatorSingle(InOutSingleChannel, ReadoutResonatorBase):
     intermediate_frequency: int = "#/inferred_intermediate_frequency"
 
-    def __post_init__(self):
-        if hasattr(self.opx_output, "upsampling_mode"):
-            self.opx_output.upsampling_mode = "mw"
+    # TODO: move it after the quam has been created to avoid warnings
+    # def __post_init__(self):
+    #     if hasattr(self.opx_output, "upsampling_mode"):
+    #         self.opx_output.upsampling_mode = "mw"
 
     def set_output_power(
         self,

--- a/quam_builder/architecture/quantum_dots/components/voltage_gate.py
+++ b/quam_builder/architecture/quantum_dots/components/voltage_gate.py
@@ -1,7 +1,8 @@
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Dict, Generator, Optional, Sequence, Union
 
-from quam.components import Channel, SingleChannel
+from quam.components import SingleChannel
 from quam.core import quam_dataclass
+from quam.core.quam_classes import QuamBase
 
 from .readout_transport import ANY_READOUT_TRANSPORT
 from .readout_resonator import ANY_READOUT_RESONATOR
@@ -22,8 +23,9 @@ class VoltageGate(SingleChannel):
             automatically. Default is None.
         offset_parameter: The optional DC offset of the voltage gate
             Can be e.g. a QDAC channel.
-        opx_output: When ``None``, the gate is **QDAC-only** (no OPX/LF analog port). QUA config then omits
-            ``singleInput``; use :attr:`dac_spec` / external drivers for DC.
+        opx_output: When ``None``, the gate is **QDAC-only** (no OPX/LF analog port). It is omitted from
+            :meth:`~quam.core.quam_classes.QuamRoot.generate_config` (no ``elements`` entry, no sticky);
+            use :attr:`dac_spec` / external drivers for DC.
 
     Example:
         >>>
@@ -79,10 +81,17 @@ class VoltageGate(SingleChannel):
         if self.settling_time is not None:
             self.wait(int(self.settling_time) // 4 * 4)
 
-    def apply_to_config(self, config: Dict[str, dict]) -> None:
-        """Skip OPX ``singleInput`` when this gate has no OPX analog port (external / QDAC-only DC)."""
+    def iterate_components(
+        self, skip_elems: Optional[Sequence[QuamBase]] = None
+    ) -> Generator[QuamBase, None, None]:
+        """QDAC-only gates are excluded from QUA config generation (no OPX element conflicts)."""
         if self.opx_output is None:
-            Channel.apply_to_config(self, config)
+            return
+        yield from super().iterate_components(skip_elems=skip_elems)
+
+    def apply_to_config(self, config: Dict[str, dict]) -> None:
+        """Only OPX-backed gates contribute to ``elements``; QDAC-only gates skip via :meth:`iterate_components`."""
+        if self.opx_output is None:
             return
         super().apply_to_config(config)
 

--- a/quam_builder/architecture/quantum_dots/components/voltage_gate.py
+++ b/quam_builder/architecture/quantum_dots/components/voltage_gate.py
@@ -1,6 +1,6 @@
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
-from quam.components import SingleChannel
+from quam.components import Channel, SingleChannel
 from quam.core import quam_dataclass
 
 from .readout_transport import ANY_READOUT_TRANSPORT
@@ -22,6 +22,8 @@ class VoltageGate(SingleChannel):
             automatically. Default is None.
         offset_parameter: The optional DC offset of the voltage gate
             Can be e.g. a QDAC channel.
+        opx_output: When ``None``, the gate is **QDAC-only** (no OPX/LF analog port). QUA config then omits
+            ``singleInput``; use :attr:`dac_spec` / external drivers for DC.
 
     Example:
         >>>
@@ -40,6 +42,7 @@ class VoltageGate(SingleChannel):
         >>> gate.offset_parameter() # Returns 0.1V
     """
 
+    opx_output: Any = None
     attenuation: float = 0.0
     settling_time: float = None
     # current_external_voltage, an attribute to help with serialising the experimental state
@@ -75,3 +78,19 @@ class VoltageGate(SingleChannel):
         """Wait for the voltage bias to settle"""
         if self.settling_time is not None:
             self.wait(int(self.settling_time) // 4 * 4)
+
+    def apply_to_config(self, config: Dict[str, dict]) -> None:
+        """Skip OPX ``singleInput`` when this gate has no OPX analog port (external / QDAC-only DC)."""
+        if self.opx_output is None:
+            Channel.apply_to_config(self, config)
+            return
+        super().apply_to_config(config)
+
+    def set_dc_offset(self, offset):  # noqa: ANN001 — match SingleChannel API
+        """Raise for QDAC-only gates; OPX has no DC line to offset."""
+        if self.opx_output is None:
+            raise RuntimeError(
+                "VoltageGate has no OPX analog output (QDAC-only wiring); "
+                "cannot use set_dc_offset on the OPX. Control DC via dac_spec / external DAC."
+            )
+        super().set_dc_offset(offset)

--- a/quam_builder/architecture/quantum_dots/macro_engine/wiring.py
+++ b/quam_builder/architecture/quantum_dots/macro_engine/wiring.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 import tomllib
 
+from qm.qua._dsl import amplitude
 from quam.core.macro import QuamMacro
 
 from quam_builder.architecture.quantum_dots.operations.macro_registry import (
@@ -28,11 +29,13 @@ from quam_builder.architecture.quantum_dots.operations.component_pulse_catalog i
     register_default_component_pulse_factories,
     _make_xy_pulse_factories,
     _make_readout_pulse,
+    _make_baseband_pulse,
 )
 from quam_builder.architecture.quantum_dots.macro_engine.overrides import (
     ComponentOverrides,
     _convert_typed_overrides,
 )
+from quam_builder.tools.voltage_sequence import DEFAULT_PULSE_NAME
 
 __all__ = [
     "wire_machine_macros",
@@ -278,6 +281,23 @@ def _ensure_default_pulses(machine: Any) -> None:
             if "readout" not in operations:
                 operations["readout"] = _make_readout_pulse()
 
+    physical_channels = getattr(machine, "physical_channels", None)
+    if isinstance(physical_channels, Mapping):
+        for physical_channel in physical_channels.values():
+            if physical_channel.opx_output is not None:
+                operations = getattr(physical_channel, "operations", None)
+                if operations is None:
+                    continue
+                if DEFAULT_PULSE_NAME not in operations:
+                    output_mode = getattr(physical_channel.opx_output, "output_mode", None)
+                    if output_mode is None:
+                        operations[DEFAULT_PULSE_NAME] = _make_baseband_pulse(0.25)
+                    elif output_mode == "direct":
+                        operations[DEFAULT_PULSE_NAME] = _make_baseband_pulse(0.25)
+                    elif output_mode == "amplified":
+                        operations[DEFAULT_PULSE_NAME] = _make_baseband_pulse(1.25)
+                    else:
+                        raise ValueError("Unknown output mode '{}'".format(output_mode))
 
 def _apply_pulse_overrides(
     machine: Any,

--- a/quam_builder/architecture/quantum_dots/macro_engine/wiring.py
+++ b/quam_builder/architecture/quantum_dots/macro_engine/wiring.py
@@ -210,12 +210,17 @@ class PulseWirer:
         Args:
             machine: Target machine whose channels receive default pulses.
         """
-        self._wire_xy_pulses(machine)
+        self._wire_baseband_pulses(machine)
         self._wire_readout_pulses(machine)
+        self._wire_xy_pulses(machine)
 
     @staticmethod
     def _wire_xy_pulses(machine: object) -> None:
         qubits = getattr(machine, "qubits", None)
+
+        if not isinstance(qubits, Mapping):
+            return
+
         for qubit in qubits.values():
             if qubit.xy is None:
                 continue

--- a/quam_builder/architecture/quantum_dots/macro_engine/wiring.py
+++ b/quam_builder/architecture/quantum_dots/macro_engine/wiring.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any, Iterable
 
-from qm.qua._dsl import amplitude
 from quam.core.macro import QuamMacro
 
 from quam_builder.architecture.quantum_dots.operations.macro_catalog import (
@@ -29,7 +28,7 @@ from quam_builder.architecture.quantum_dots.operations.macro_catalog import (
 from quam_builder.architecture.quantum_dots.operations.pulse_catalog import (
     make_readout_pulse,
     make_xy_pulse_factories,
-    _make_baseband_pulse,
+    make_baseband_pulse,
 )
 from quam_builder.tools.voltage_sequence import DEFAULT_PULSE_NAME
 
@@ -272,11 +271,11 @@ class PulseWirer:
                 if DEFAULT_PULSE_NAME not in operations:
                     output_mode = getattr(physical_channel.opx_output, "output_mode", None)
                     if output_mode is None:
-                        operations[DEFAULT_PULSE_NAME] = _make_baseband_pulse(0.25)
+                        operations[DEFAULT_PULSE_NAME] = make_baseband_pulse(0.25)
                     elif output_mode == "direct":
-                        operations[DEFAULT_PULSE_NAME] = _make_baseband_pulse(0.25)
+                        operations[DEFAULT_PULSE_NAME] = make_baseband_pulse(0.25)
                     elif output_mode == "amplified":
-                        operations[DEFAULT_PULSE_NAME] = _make_baseband_pulse(1.25)
+                        operations[DEFAULT_PULSE_NAME] = make_baseband_pulse(1.25)
                     else:
                         raise ValueError("Unknown output mode '{}'".format(output_mode))
 

--- a/quam_builder/architecture/quantum_dots/macro_engine/wiring.py
+++ b/quam_builder/architecture/quantum_dots/macro_engine/wiring.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any, Iterable
 
+from qm.qua._dsl import amplitude
 from quam.core.macro import QuamMacro
 
 from quam_builder.architecture.quantum_dots.operations.macro_catalog import (
@@ -28,7 +29,9 @@ from quam_builder.architecture.quantum_dots.operations.macro_catalog import (
 from quam_builder.architecture.quantum_dots.operations.pulse_catalog import (
     make_readout_pulse,
     make_xy_pulse_factories,
+    _make_baseband_pulse,
 )
+from quam_builder.tools.voltage_sequence import DEFAULT_PULSE_NAME
 
 __all__ = [
     "wire_machine_macros",
@@ -230,15 +233,16 @@ class PulseWirer:
         if sensor_dots is not None:
             sensor_to_qdpair_mapping = {s : [] for s in list(sensor_dots.keys())}
             quantum_dot_pairs = getattr(machine, "quantum_dot_pairs", None)
-            if quantum_dot_pairs is not None: 
-                for qd_pair_name, qd_pair in quantum_dot_pairs.items(): 
+            if quantum_dot_pairs is not None:
+                for qd_pair_name, qd_pair in quantum_dot_pairs.items():
                     sensors_for_qdp = [sen.name for sen in qd_pair.sensor_dots]
-                    for s in sensor_dots.keys(): 
-                        if s in sensors_for_qdp: 
+                    for s in sensor_dots.keys():
+                        if s in sensors_for_qdp:
                             sensor_to_qdpair_mapping[s].append(qd_pair_name)
 
         if not isinstance(sensor_dots, Mapping):
             return
+
         for sensor_dot in sensor_dots.values():
             resonator = getattr(sensor_dot, "readout_resonator", None)
             if resonator is None:
@@ -248,11 +252,33 @@ class PulseWirer:
                 continue
             if "readout" not in operations:
                 operations["readout"] = make_readout_pulse()
-            for qd_pair_name in sensor_to_qdpair_mapping[sensor_dot.name]: 
+            for qd_pair_name in sensor_to_qdpair_mapping[sensor_dot.name]:
                 op_name = f"readout_{qd_pair_name}"
-                if op_name not in operations: 
+                if op_name not in operations:
                     operations[op_name] = make_readout_pulse(qd_pair_name)
 
+    @staticmethod
+    def _wire_baseband_pulses(machine: object) -> None:
+        physical_channels = getattr(machine, "physical_channels", None)
+
+        if not isinstance(physical_channels, Mapping):
+            return
+
+        for physical_channel in physical_channels.values():
+            if physical_channel.opx_output is not None:
+                operations = getattr(physical_channel, "operations", None)
+                if operations is None:
+                    continue
+                if DEFAULT_PULSE_NAME not in operations:
+                    output_mode = getattr(physical_channel.opx_output, "output_mode", None)
+                    if output_mode is None:
+                        operations[DEFAULT_PULSE_NAME] = _make_baseband_pulse(0.25)
+                    elif output_mode == "direct":
+                        operations[DEFAULT_PULSE_NAME] = _make_baseband_pulse(0.25)
+                    elif output_mode == "amplified":
+                        operations[DEFAULT_PULSE_NAME] = _make_baseband_pulse(1.25)
+                    else:
+                        raise ValueError("Unknown output mode '{}'".format(output_mode))
 
 # ---------------------------------------------------------------------------
 # Top-level entry point

--- a/quam_builder/architecture/quantum_dots/operations/component_pulse_catalog.py
+++ b/quam_builder/architecture/quantum_dots/operations/component_pulse_catalog.py
@@ -39,13 +39,14 @@ Usage::
 from __future__ import annotations
 
 from quam.components.channels import SingleChannel
-from quam.components.pulses import SquareReadoutPulse
+from quam.components.pulses import SquareReadoutPulse, SquarePulse
 
 from quam_builder.architecture.quantum_dots.components.pulses import ScalableGaussianPulse
 from quam_builder.architecture.quantum_dots.operations.names import DrivePulseName
 from quam_builder.architecture.quantum_dots.operations.pulse_registry import (
     register_component_pulse_factories,
 )
+from quam_builder.tools.voltage_sequence import DEFAULT_PULSE_NAME, MIN_PULSE_DURATION_NS
 
 _REGISTERED = False
 
@@ -120,6 +121,20 @@ def _make_readout_pulse():
         amplitude=_READOUT_AMP,
     )
 
+def _make_baseband_pulse(amplitude: float):
+    """Build default baseband pulse for all voltage gates connected to the OPX.
+
+    Args:
+        amplitude: The baseband pulse amplitude in Volt.
+
+    Returns:
+        ``SquarePulse`` with id ``DEFAULT_PULSE_NAME``, length MIN_PULSE_DURATION_NS ns, and specified amplitude.
+    """
+    return SquarePulse(
+        id=DEFAULT_PULSE_NAME,
+        length=MIN_PULSE_DURATION_NS,
+        amplitude=amplitude,
+    )
 
 def register_default_component_pulse_factories() -> None:
     """Register built-in pulse factories for core quantum-dot component types.

--- a/quam_builder/architecture/quantum_dots/operations/pulse_catalog.py
+++ b/quam_builder/architecture/quantum_dots/operations/pulse_catalog.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 import numpy as np
 from quam.components.channels import SingleChannel
-from quam.components.pulses import SquareReadoutPulse
+from quam.components.pulses import SquareReadoutPulse, SquarePulse
 
 from quam_builder.architecture.quantum_dots.components.pulses import (
     ScalableDragPulse,
@@ -27,6 +27,7 @@ from quam_builder.architecture.quantum_dots.operations.names import (
     DrivePulseName,
     TwoQubitMacroName,
 )
+from quam_builder.tools.voltage_sequence import DEFAULT_PULSE_NAME, MIN_PULSE_DURATION_NS
 
 __all__ = [
     "PULSE_FAMILIES",
@@ -171,4 +172,19 @@ def make_readout_pulse(dot_pair_name: Optional[str] = None) -> SquareReadoutPuls
         id="readout" if dot_pair_name is None else f"readout_{dot_pair_name}",
         length=DEFAULTS.readout.length,
         amplitude=DEFAULTS.readout.amplitude,
+    )
+
+def make_baseband_pulse(amplitude: float):
+    """Build default baseband pulse for all voltage gates connected to the OPX.
+
+    Args:
+        amplitude: The baseband pulse amplitude in Volt.
+
+    Returns:
+        ``SquarePulse`` with id ``DEFAULT_PULSE_NAME``, length MIN_PULSE_DURATION_NS ns, and specified amplitude.
+    """
+    return SquarePulse(
+        id=DEFAULT_PULSE_NAME,
+        length=MIN_PULSE_DURATION_NS,
+        amplitude=amplitude,
     )

--- a/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
+++ b/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
@@ -359,14 +359,13 @@ class BaseQuamQD(QuamRoot):
 
     def wire_voltage_gate_qdac(
         self,
-        voltage_gate: VoltageGate,
+        voltage_gate: Union[VoltageGate, Channel],
         *,
         qdac_output_port: int,
         dac_name: str = "qdac",
         with_trigger_channel: bool = False,
         digital_output_key: str = "qdac_trig_0",
         qdac_trigger_in: Optional[int] = None,
-        trigger_pulse_length_ns: int = 100,
     ) -> None:
         """Attach QDAC metadata and optionally move a digital trigger under a wrapper ``Channel``.
 
@@ -385,8 +384,6 @@ class BaseQuamQD(QuamRoot):
             digital_output_key: Name of the digital output on the gate (default wiring
                 uses ``qdac_trig_0``).
             qdac_trigger_in: Optional QDAC external trigger port.
-            trigger_pulse_length_ns: Length of the default ``trigger`` pulse on the
-                wrapper channel when ``with_trigger_channel`` is True.
         """
         if with_trigger_channel:
             if digital_output_key not in voltage_gate.digital_outputs:
@@ -395,30 +392,16 @@ class BaseQuamQD(QuamRoot):
                     f"{getattr(voltage_gate, 'name', voltage_gate)!r}"
                 )
             dig = voltage_gate.digital_outputs[digital_output_key]
-            digital_ch = Channel(
-                id=f"qdac_trig_{qdac_output_port}",
-                digital_outputs={},
-                operations={
-                    "trigger": pulses.Pulse(
-                        length=trigger_pulse_length_ns, digital_marker="ON"
-                    )
-                },
-            )
             voltage_gate.dac_spec = QdacSpec(
                 dac_name=dac_name,
                 qdac_output_port=qdac_output_port,
-                opx_trigger_out=digital_ch,
+                opx_trigger_out=dig.get_reference(),
                 qdac_trigger_in=qdac_trigger_in,
             )
-            del voltage_gate.digital_outputs[digital_output_key]
-            dig.parent = None
-            digital_ch.digital_outputs["trigger"] = dig
         else:
             voltage_gate.dac_spec = QdacSpec(
                 dac_name=dac_name,
                 qdac_output_port=qdac_output_port,
-                opx_trigger_out=None,
-                qdac_trigger_in=qdac_trigger_in,
             )
 
     def apply_qdac_channel_mapping(
@@ -429,7 +412,6 @@ class BaseQuamQD(QuamRoot):
         digital_output_key: str = "qdac_trig_0",
         dac_name: str = "qdac",
         qdac_trigger_in: Optional[int] = None,
-        trigger_pulse_length_ns: int = 100,
     ) -> None:
         """Apply :meth:`wire_voltage_gate_qdac` to every ``VoltageGate`` listed in ``qdac_mapping``.
 
@@ -458,7 +440,6 @@ class BaseQuamQD(QuamRoot):
                 with_trigger_channel=bool(entry.get("trigger", False)),
                 digital_output_key=digital_output_key,
                 qdac_trigger_in=qdac_trigger_in,
-                trigger_pulse_length_ns=trigger_pulse_length_ns,
             )
 
     def register_quantum_dot_pair(

--- a/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
+++ b/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
@@ -194,6 +194,8 @@ class BaseQuamQD(QuamRoot):
         for dac_name, config in self.dac_config.items():
             module = importlib.import_module(config["driver_module"])
             dac_class = getattr(module, config["driver_class"])
+            if dac_name in dac_instances:
+                dac_instances[dac_name]["driver"].close()
             dac_instances[dac_name] = {
                 "driver": dac_class(dac_name, **config["connection"]),
                 "channel_method": config["channel_method"],

--- a/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
+++ b/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
@@ -787,9 +787,12 @@ class BaseQuamQD(QuamRoot):
         except:
             raise RuntimeError(f"Failed to initialise qubit {qubit_name}")
 
-    def connect(self) -> QuantumMachinesManager:
+    def connect(self, reset_voltages: bool = False, skip_dacs: bool=False) -> QuantumMachinesManager:
         """Open a Quantum Machine Manager with the credentials ("host" and "cluster_name") as defined in the network file.
 
+        Args:
+            reset_voltages (bool): Whether to reset the voltages of each of the channels to the last-applied voltage, saved in the Quam state.
+            skip_dacs (bool): Whether to connect to the da==registered DACs.
         Returns:
             QuantumMachinesManager: The opened Quantum Machine Manager.
         """
@@ -800,7 +803,12 @@ class BaseQuamQD(QuamRoot):
         )
         if "port" in self.network:
             settings["port"] = self.network["port"]
+
         self.qmm = QuantumMachinesManager(**settings)
+
+        ## TODO: need to also call self.create_virtual_dc_set("main_qpu") every time?
+        if self.dac_config and ~skip_dacs:
+            self.connect_to_external_source(reset_voltages)
         return self.qmm
 
     def get_octave_config(self) -> QmOctaveConfig:

--- a/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
+++ b/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
@@ -775,7 +775,7 @@ class BaseQuamQD(QuamRoot):
 
         Args:
             reset_voltages (bool): Whether to reset the voltages of each of the channels to the last-applied voltage, saved in the Quam state.
-            skip_dacs (bool): Whether to connect to the da==registered DACs.
+            skip_dacs (bool): Whether to connect to the registered DACs.
         Returns:
             QuantumMachinesManager: The opened Quantum Machine Manager.
         """
@@ -790,7 +790,7 @@ class BaseQuamQD(QuamRoot):
         self.qmm = QuantumMachinesManager(**settings)
 
         ## TODO: need to also call self.create_virtual_dc_set("main_qpu") every time?
-        if self.dac_config and ~skip_dacs:
+        if self.dac_config and not skip_dacs:
             self.connect_to_external_source(reset_voltages)
         return self.qmm
 

--- a/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
+++ b/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
@@ -13,7 +13,6 @@ from typing import (
 from dataclasses import field
 import numpy as np
 import importlib
-import json
 
 from qm import QuantumMachinesManager
 from qm.octave import QmOctaveConfig
@@ -65,6 +64,8 @@ class BaseQuamQD(QuamRoot):
         global_gates (Dict[str, GlobalGate]): Global gate components associated with back gate, reservoirs, or splitter gates.
         wiring (dict): The wiring configuration.
         network (dict): The network configuration.
+        dac_config (dict): Per-DAC driver settings (same structure as passed to :meth:`set_dac_config`),
+            serialised alongside ``wiring`` and ``network`` in ``wiring.json``.
         ports (Union[FEMPortsContainer, OPXPlusPortsContainer]): The ports container.
         _data_handler (ClassVar[DataHandler]): The data handler.
         qmm (ClassVar[Optional[QuantumMachinesManager]]): The Quantum Machines Manager.
@@ -107,6 +108,7 @@ class BaseQuamQD(QuamRoot):
     mixers: Dict[str, FrequencyConverter] = field(default_factory=dict)
     wiring: dict = field(default_factory=dict)
     network: dict = field(default_factory=dict)
+    dac_config: Dict[str, Any] = field(default_factory=dict)
 
     ports: Union[FEMPortsContainer, OPXPlusPortsContainer] = None
 
@@ -118,7 +120,13 @@ class BaseQuamQD(QuamRoot):
 
         This method can be overridden by subclasses to provide a custom serialiser.
         """
-        return JSONSerialiser(content_mapping={"wiring": "wiring.json", "network": "wiring.json"})
+        return JSONSerialiser(
+            content_mapping={
+                "wiring": "wiring.json",
+                "network": "wiring.json",
+                "dac_config": "wiring.json",
+            }
+        )
 
     def get_voltage_sequence(self, gate_set_id: str) -> VoltageSequence:
         if gate_set_id not in self.voltage_sequences:
@@ -165,22 +173,25 @@ class BaseQuamQD(QuamRoot):
         Args:
             reset_voltages (bool): Whether to reset the voltages of each of the channels to the last-applied voltage, saved in the Quam state.
 
-        The dac configuration must be saved in the same directory as the quam state.json file, as a dac_api.json. The format must be as follows:
+        DAC entries must be set on :attr:`dac_config` (e.g. via :meth:`set_dac_config`) and are
+        stored in ``wiring.json`` when saving. Example entry:
+
         {
             "driver_module": "qcodes_contrib_drivers.drivers.QDevil.QDAC2",
             "driver_class": "QDac2",
             "connection": {"visalib": "@py", "address": "TCPIP::172.16.33.101::5025::SOCKET"},
             "channel_method": "channel",
-            "accessor": "dc_constant_V"
+            "accessor": "dc_constant_V",
+            "is_qdac": true
         }
         """
-        if self._dac_config is None:
+        if not self.dac_config:
             raise ValueError(
-                "No DAC configurations found. Please save a directory of DACs with the Quam state."
+                "No DAC configurations found. Set them with set_dac_config(...) or load from wiring.json."
             )
 
         dac_instances = self.dacs
-        for dac_name, config in self._dac_config.items():
+        for dac_name, config in self.dac_config.items():
             module = importlib.import_module(config["driver_module"])
             dac_class = getattr(module, config["driver_class"])
             dac_instances[dac_name] = {
@@ -850,15 +861,22 @@ class BaseQuamQD(QuamRoot):
         d.pop("dacs", None)
         return d
 
-    def set_dac_config(self, config: Dict) -> None:
-        """Set the DAC configuration(s). This will not be serialised as a Quam field"""
-        if config is None:
-            object.__setattr__(self, "_dac_config", None)
-            return
+    def set_dac_config(self, config: Optional[Dict[str, Any]]) -> None:
+        """Set DAC driver entries by name. Persisted in ``wiring.json`` (with ``wiring`` / ``network``).
 
+        Pass a dict mapping logical DAC names (e.g. ``qdac1``, ``main``) to driver specs. If you
+        pass a single-driver flat dict (with top-level ``driver_module``), it is wrapped as
+        ``{"main": config}``.
+        """
+        if not config:
+            self.dac_config = {}
+            return
         if "driver_module" in config:
-            config = {"main": config}
-        object.__setattr__(self, "_dac_config", config)
+            self.dac_config = {"main": dict(config)}
+        else:
+            self.dac_config = {
+                k: dict(v) if isinstance(v, Mapping) else v for k, v in config.items()
+            }
 
     @classmethod
     def load(
@@ -881,27 +899,6 @@ class BaseQuamQD(QuamRoot):
                 track_integrated_voltage=True
             )
 
-        # load the dac_api from the same directory too
-        if not isinstance(filepath_or_dict, dict):
-            if filepath_or_dict is not None:
-                state_dir = Path(filepath_or_dict)
-                if state_dir.is_file():
-                    state_dir = state_dir.parent
-            else:
-                state_path = Path(instance.serialiser._get_state_path())
-                state_dir = state_path.parent if state_path.is_file() else state_path
-            dac_dir = state_dir / "dac"
-            if dac_dir.is_dir():
-                dac_configs = {}
-                for f in sorted(dac_dir.glob("*.jsonc")):
-                    with open(f) as fh:
-                        dac_configs[f.stem] = json.load(fh)
-                instance.set_dac_config(dac_configs if dac_configs else None)
-            else:
-                instance.set_dac_config(None)
-        else:
-            instance.set_dac_config(None)
-
         # We can also update the state_tracker here to hold the value held by QuantumDot.current_voltage.
 
         from quam_builder.architecture.quantum_dots.macro_engine import wire_machine_macros
@@ -923,18 +920,3 @@ class BaseQuamQD(QuamRoot):
             include_defaults,
             ignore,
         )
-
-        # Save the DAC driver API as a separate JSON file
-        if getattr(self, "_dac_config", None) is not None:
-            if path is not None:
-                state_dir = Path(path)
-                if state_dir.is_file():
-                    state_dir = state_dir.parent
-            else:
-                state_path = Path(self.serialiser._get_state_path())
-                state_dir = state_path.parent if state_path.is_file() else state_path
-            dac_dir = state_dir / "dac"
-            dac_dir.mkdir(exist_ok=True)
-            for name, config in self._dac_config.items():
-                with open(dac_dir / f"{name}.jsonc", "w") as f:
-                    json.dump(config, f, indent=2)

--- a/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
+++ b/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
@@ -364,7 +364,7 @@ class BaseQuamQD(QuamRoot):
         qdac_output_port: int,
         dac_name: str = "qdac",
         with_trigger_channel: bool = False,
-        digital_output_key: str = "qdac_trig_0",
+        digital_output_key: str = "qdac_trig",
         qdac_trigger_in: Optional[int] = None,
     ) -> None:
         """Attach QDAC metadata and optionally move a digital trigger under a wrapper ``Channel``.
@@ -382,7 +382,7 @@ class BaseQuamQD(QuamRoot):
             with_trigger_channel: If True, move ``digital_output_key`` into a wrapper
                 ``Channel`` referenced by ``QdacSpec.opx_trigger_out``.
             digital_output_key: Name of the digital output on the gate (default wiring
-                uses ``qdac_trig_0``).
+                uses ``qdac_trig``).
             qdac_trigger_in: Optional QDAC external trigger port.
         """
         if with_trigger_channel:
@@ -409,7 +409,7 @@ class BaseQuamQD(QuamRoot):
         gate_set_id: str,
         qdac_mapping: Mapping[str, Mapping[str, Any]],
         *,
-        digital_output_key: str = "qdac_trig_0",
+        digital_output_key: str = "qdac_trig",
         dac_name: str = "qdac",
         qdac_trigger_in: Optional[int] = None,
     ) -> None:

--- a/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
+++ b/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
@@ -412,14 +412,13 @@ class BaseQuamQD(QuamRoot):
 
     def wire_voltage_gate_qdac(
         self,
-        voltage_gate: VoltageGate,
+        voltage_gate: Union[VoltageGate, Channel],
         *,
         qdac_output_port: int,
         dac_name: str = "qdac",
         with_trigger_channel: bool = False,
         digital_output_key: str = "qdac_trig_0",
         qdac_trigger_in: Optional[int] = None,
-        trigger_pulse_length_ns: int = 100,
     ) -> None:
         """Attach QDAC metadata and optionally move a digital trigger under a wrapper ``Channel``.
 
@@ -438,8 +437,6 @@ class BaseQuamQD(QuamRoot):
             digital_output_key: Name of the digital output on the gate (default wiring
                 uses ``qdac_trig_0``).
             qdac_trigger_in: Optional QDAC external trigger port.
-            trigger_pulse_length_ns: Length of the default ``trigger`` pulse on the
-                wrapper channel when ``with_trigger_channel`` is True.
         """
         if with_trigger_channel:
             if digital_output_key not in voltage_gate.digital_outputs:
@@ -448,30 +445,16 @@ class BaseQuamQD(QuamRoot):
                     f"{getattr(voltage_gate, 'name', voltage_gate)!r}"
                 )
             dig = voltage_gate.digital_outputs[digital_output_key]
-            digital_ch = Channel(
-                id=f"qdac_trig_{qdac_output_port}",
-                digital_outputs={},
-                operations={
-                    "trigger": pulses.Pulse(
-                        length=trigger_pulse_length_ns, digital_marker="ON"
-                    )
-                },
-            )
             voltage_gate.dac_spec = QdacSpec(
                 dac_name=dac_name,
                 qdac_output_port=qdac_output_port,
-                opx_trigger_out=digital_ch,
+                opx_trigger_out=dig.get_reference(),
                 qdac_trigger_in=qdac_trigger_in,
             )
-            del voltage_gate.digital_outputs[digital_output_key]
-            dig.parent = None
-            digital_ch.digital_outputs["trigger"] = dig
         else:
             voltage_gate.dac_spec = QdacSpec(
                 dac_name=dac_name,
                 qdac_output_port=qdac_output_port,
-                opx_trigger_out=None,
-                qdac_trigger_in=qdac_trigger_in,
             )
 
     def apply_qdac_channel_mapping(
@@ -482,7 +465,6 @@ class BaseQuamQD(QuamRoot):
         digital_output_key: str = "qdac_trig_0",
         dac_name: str = "qdac",
         qdac_trigger_in: Optional[int] = None,
-        trigger_pulse_length_ns: int = 100,
     ) -> None:
         """Apply :meth:`wire_voltage_gate_qdac` to every ``VoltageGate`` listed in ``qdac_mapping``.
 
@@ -511,7 +493,6 @@ class BaseQuamQD(QuamRoot):
                 with_trigger_channel=bool(entry.get("trigger", False)),
                 digital_output_key=digital_output_key,
                 qdac_trigger_in=qdac_trigger_in,
-                trigger_pulse_length_ns=trigger_pulse_length_ns,
             )
 
     def _ensure_default_detuning_axis_for_quantum_dot_pair(

--- a/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
+++ b/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
@@ -891,10 +891,12 @@ class BaseQuamQD(QuamRoot):
         except:
             raise RuntimeError(f"Failed to initialise qubit {qubit_name}")
 
-    def connect(self, timeout: Optional[float] = None) -> QuantumMachinesManager:
+    def connect(self, skip_dacs: bool=False, reset_voltages: bool = False, timeout: Optional[float] = None) -> QuantumMachinesManager:
         """Open a Quantum Machine Manager with the credentials ("host" and "cluster_name") as defined in the network file.
 
         Args:
+            skip_dacs (bool): Whether to connect to the registered DACs.
+            reset_voltages (bool): Whether to reset the voltages of each of the channels to the last-applied voltage, saved in the Quam state.
             timeout: Timeout in seconds for gRPC API calls including program compilation.
                 Defaults to the QM SDK default (120 s). Increase for programs with many
                 QUA variables that take longer to compile.
@@ -912,6 +914,10 @@ class BaseQuamQD(QuamRoot):
         if timeout is not None:
             settings["timeout"] = timeout
         self.qmm = QuantumMachinesManager(**settings)
+
+        ## TODO: need to also call self.create_virtual_dc_set("main_qpu") every time?
+        if self.dac_config and ~skip_dacs:
+            self.connect_to_external_source(reset_voltages)
         return self.qmm
 
     def get_octave_config(self) -> QmOctaveConfig:

--- a/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
+++ b/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
@@ -237,6 +237,8 @@ class BaseQuamQD(QuamRoot):
         for dac_name, config in self.dac_config.items():
             module = importlib.import_module(config["driver_module"])
             dac_class = getattr(module, config["driver_class"])
+            if dac_name in dac_instances:
+                dac_instances[dac_name]["driver"].close()
             dac_instances[dac_name] = {
                 "driver": dac_class(dac_name, **config["connection"]),
                 "channel_method": config["channel_method"],

--- a/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
+++ b/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
@@ -880,6 +880,7 @@ class BaseQuamQD(QuamRoot):
         Args:
             skip_dacs (bool): Whether to connect to the registered DACs.
             reset_voltages (bool): Whether to reset the voltages of each of the channels to the last-applied voltage, saved in the Quam state.
+            skip_dacs (bool): Whether to connect to the registered DACs.
             timeout: Timeout in seconds for gRPC API calls including program compilation.
                 Defaults to the QM SDK default (120 s). Increase for programs with many
                 QUA variables that take longer to compile.
@@ -899,7 +900,7 @@ class BaseQuamQD(QuamRoot):
         self.qmm = QuantumMachinesManager(**settings)
 
         ## TODO: need to also call self.create_virtual_dc_set("main_qpu") every time?
-        if self.dac_config and ~skip_dacs:
+        if self.dac_config and not skip_dacs:
             self.connect_to_external_source(reset_voltages)
         return self.qmm
 

--- a/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
+++ b/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
@@ -16,7 +16,6 @@ from dataclasses import field
 import numpy as np
 from collections import defaultdict
 import importlib
-import json
 
 from qm import QuantumMachinesManager, QuantumMachine
 from qm.octave import QmOctaveConfig
@@ -68,6 +67,8 @@ class BaseQuamQD(QuamRoot):
         global_gates (Dict[str, GlobalGate]): Global gate components associated with back gate, reservoirs, or splitter gates.
         wiring (dict): The wiring configuration.
         network (dict): The network configuration.
+        dac_config (dict): Per-DAC driver settings (same structure as passed to :meth:`set_dac_config`),
+            serialised alongside ``wiring`` and ``network`` in ``wiring.json``.
         ports (Union[FEMPortsContainer, OPXPlusPortsContainer]): The ports container.
         _data_handler (ClassVar[DataHandler]): The data handler.
         qmm (ClassVar[Optional[QuantumMachinesManager]]): The Quantum Machines Manager.
@@ -110,6 +111,7 @@ class BaseQuamQD(QuamRoot):
     mixers: Dict[str, FrequencyConverter] = field(default_factory=dict)
     wiring: dict = field(default_factory=dict)
     network: dict = field(default_factory=dict)
+    dac_config: Dict[str, Any] = field(default_factory=dict)
 
     ports: Union[FEMPortsContainer, OPXPlusPortsContainer] = None
 
@@ -150,7 +152,11 @@ class BaseQuamQD(QuamRoot):
         This method can be overridden by subclasses to provide a custom serialiser.
         """
         return JSONSerialiser(
-            content_mapping={"wiring": "wiring.json", "network": "wiring.json"}
+            content_mapping={
+                "wiring": "wiring.json",
+                "network": "wiring.json",
+                "dac_config": "wiring.json",
+            }
         )
 
     def get_voltage_sequence(self, gate_set_id: str) -> VoltageSequence:
@@ -210,22 +216,25 @@ class BaseQuamQD(QuamRoot):
         Args:
             reset_voltages (bool): Whether to reset the voltages of each of the channels to the last-applied voltage, saved in the Quam state.
 
-        The dac configuration must be saved in the same directory as the quam state_old.json file, as a dac_api.json. The format must be as follows:
+        DAC entries must be set on :attr:`dac_config` (e.g. via :meth:`set_dac_config`) and are
+        stored in ``wiring.json`` when saving. Example entry:
+
         {
             "driver_module": "qcodes_contrib_drivers.drivers.QDevil.QDAC2",
             "driver_class": "QDac2",
             "connection": {"visalib": "@py", "address": "TCPIP::172.16.33.101::5025::SOCKET"},
             "channel_method": "channel",
-            "accessor": "dc_constant_V"
+            "accessor": "dc_constant_V",
+            "is_qdac": true
         }
         """
-        if self._dac_config is None:
+        if not self.dac_config:
             raise ValueError(
-                "No DAC configurations found. Please save a directory of DACs with the Quam state."
+                "No DAC configurations found. Set them with set_dac_config(...) or load from wiring.json."
             )
 
         dac_instances = self.dacs
-        for dac_name, config in self._dac_config.items():
+        for dac_name, config in self.dac_config.items():
             module = importlib.import_module(config["driver_module"])
             dac_class = getattr(module, config["driver_class"])
             dac_instances[dac_name] = {
@@ -968,15 +977,22 @@ class BaseQuamQD(QuamRoot):
         d.pop("dacs", None)
         return d
 
-    def set_dac_config(self, config: Dict) -> None:
-        """Set the DAC configuration(s). This will not be serialised as a Quam field"""
-        if config is None:
-            object.__setattr__(self, "_dac_config", None)
-            return
+    def set_dac_config(self, config: Optional[Dict[str, Any]]) -> None:
+        """Set DAC driver entries by name. Persisted in ``wiring.json`` (with ``wiring`` / ``network``).
 
+        Pass a dict mapping logical DAC names (e.g. ``qdac1``, ``main``) to driver specs. If you
+        pass a single-driver flat dict (with top-level ``driver_module``), it is wrapped as
+        ``{"main": config}``.
+        """
+        if not config:
+            self.dac_config = {}
+            return
         if "driver_module" in config:
-            config = {"main": config}
-        object.__setattr__(self, "_dac_config", config)
+            self.dac_config = {"main": dict(config)}
+        else:
+            self.dac_config = {
+                k: dict(v) if isinstance(v, Mapping) else v for k, v in config.items()
+            }
 
     @classmethod
     def load(
@@ -1001,27 +1017,6 @@ class BaseQuamQD(QuamRoot):
                 limit_play_commands=instance.limit_play_commands
             )
 
-        # load the dac_api from the same directory too
-        if not isinstance(filepath_or_dict, dict):
-            if filepath_or_dict is not None:
-                state_dir = Path(filepath_or_dict)
-                if state_dir.is_file():
-                    state_dir = state_dir.parent
-            else:
-                state_path = Path(instance.serialiser._get_state_path())
-                state_dir = state_path.parent if state_path.is_file() else state_path
-            dac_dir = state_dir / "dac"
-            if dac_dir.is_dir():
-                dac_configs = {}
-                for f in sorted(dac_dir.glob("*.jsonc")):
-                    with open(f) as fh:
-                        dac_configs[f.stem] = json.load(fh)
-                instance.set_dac_config(dac_configs if dac_configs else None)
-            else:
-                instance.set_dac_config(None)
-        else:
-            instance.set_dac_config(None)
-
         # We can also update the state_tracker here to hold the value held by QuantumDot.current_voltage.
 
         from quam_builder.architecture.quantum_dots.macro_engine import (
@@ -1045,18 +1040,3 @@ class BaseQuamQD(QuamRoot):
             include_defaults,
             ignore,
         )
-
-        # Save the DAC driver API as a separate JSON file
-        if getattr(self, "_dac_config", None) is not None:
-            if path is not None:
-                state_dir = Path(path)
-                if state_dir.is_file():
-                    state_dir = state_dir.parent
-            else:
-                state_path = Path(self.serialiser._get_state_path())
-                state_dir = state_path.parent if state_path.is_file() else state_path
-            dac_dir = state_dir / "dac"
-            dac_dir.mkdir(exist_ok=True)
-            for name, config in self._dac_config.items():
-                with open(dac_dir / f"{name}.jsonc", "w") as f:
-                    json.dump(config, f, indent=2)

--- a/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
+++ b/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
@@ -417,7 +417,7 @@ class BaseQuamQD(QuamRoot):
         qdac_output_port: int,
         dac_name: str = "qdac",
         with_trigger_channel: bool = False,
-        digital_output_key: str = "qdac_trig_0",
+        digital_output_key: str = "qdac_trig",
         qdac_trigger_in: Optional[int] = None,
     ) -> None:
         """Attach QDAC metadata and optionally move a digital trigger under a wrapper ``Channel``.
@@ -435,7 +435,7 @@ class BaseQuamQD(QuamRoot):
             with_trigger_channel: If True, move ``digital_output_key`` into a wrapper
                 ``Channel`` referenced by ``QdacSpec.opx_trigger_out``.
             digital_output_key: Name of the digital output on the gate (default wiring
-                uses ``qdac_trig_0``).
+                uses ``qdac_trig``).
             qdac_trigger_in: Optional QDAC external trigger port.
         """
         if with_trigger_channel:
@@ -462,7 +462,7 @@ class BaseQuamQD(QuamRoot):
         gate_set_id: str,
         qdac_mapping: Mapping[str, Mapping[str, Any]],
         *,
-        digital_output_key: str = "qdac_trig_0",
+        digital_output_key: str = "qdac_trig",
         dac_name: str = "qdac",
         qdac_trigger_in: Optional[int] = None,
     ) -> None:

--- a/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
+++ b/quam_builder/architecture/quantum_dots/qpu/base_quam_qd.py
@@ -975,7 +975,7 @@ class BaseQuamQD(QuamRoot):
         ``{"main": config}``.
         """
         if not config:
-            self.dac_config = {}
+            self.dac_config = {"qdac": None}
             return
         if "driver_module" in config:
             self.dac_config = {"main": dict(config)}

--- a/quam_builder/builder/qop_connectivity/build_quam_wiring.py
+++ b/quam_builder/builder/qop_connectivity/build_quam_wiring.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from qualang_tools.wirer import Connectivity
 from quam.components.ports import FEMPortsContainer, OPXPlusPortsContainer
@@ -20,6 +20,7 @@ def build_quam_wiring(
     quam_instance: AnyQuam,
     port: Optional[int] = None,
     path: Optional[Union[str, Path]] = None,
+    dac_config: Optional[Dict[str, Any]] = None,
 ) -> AnyQuam:
     """Builds the QUAM wiring configuration and saves the machine setup.
 
@@ -31,6 +32,10 @@ def build_quam_wiring(
         port (Optional[int]): The port number. Defaults to None.
         path (Optional[Union[str, Path]]): Directory to save the machine state.
             Defaults to None (uses the machine's existing save path).
+        dac_config (Optional[Dict[str, Any]]): Optional map of DAC name → driver spec
+            (same structure as :meth:`~quam_builder.architecture.quantum_dots.qpu.base_quam_qd.BaseQuamQD.set_dac_config`).
+            Stored in ``wiring.json`` next to ``wiring`` and ``network`` on quantum-dot roots
+            that support it.
 
     Returns:
         AnyQuam: The configured QUAM instance.
@@ -38,6 +43,10 @@ def build_quam_wiring(
     machine = quam_instance
     add_ports_container(connectivity, machine)
     add_name_and_ip(machine, host_ip, cluster_name, port)
+    if dac_config is not None:
+        setter = getattr(machine, "set_dac_config", None)
+        if callable(setter):
+            setter(dac_config)
     machine.wiring = create_wiring(connectivity)
     machine.save(path)
     return machine

--- a/quam_builder/builder/qop_connectivity/build_quam_wiring.py
+++ b/quam_builder/builder/qop_connectivity/build_quam_wiring.py
@@ -60,6 +60,10 @@ def add_ports_container(connectivity: Connectivity, machine: AnyQuam):
                     machine.ports = FEMPortsContainer()
                 elif channel.instrument_id in ["opx+"]:
                     machine.ports = OPXPlusPortsContainer()
+                elif channel.instrument_id == "qdac2" and machine.ports is None:
+                    # No LF/OPX channels on this element: still attach a ports container so QUAM
+                    # machine state is valid (QDAC DC lines use integer wiring keys, not #/ports/...).
+                    machine.ports = OPXPlusPortsContainer()
 
 
 def add_name_and_ip(machine: AnyQuam, host_ip: str, cluster_name: str, port: Union[int, None]):

--- a/quam_builder/builder/qop_connectivity/build_quam_wiring.py
+++ b/quam_builder/builder/qop_connectivity/build_quam_wiring.py
@@ -60,6 +60,10 @@ def add_ports_container(connectivity: Connectivity, machine: AnyQuam):
                     machine.ports = FEMPortsContainer()
                 elif channel.instrument_id in ["opx+"]:
                     machine.ports = OPXPlusPortsContainer()
+                elif channel.instrument_id == "qdac2" and machine.ports is None:
+                    # No LF/OPX channels on this element: still attach a ports container so QUAM
+                    # machine state is valid (QDAC DC lines use integer wiring keys, not #/ports/...).
+                    machine.ports = OPXPlusPortsContainer()
 
 
 def add_name_and_ip(

--- a/quam_builder/builder/qop_connectivity/build_quam_wiring.py
+++ b/quam_builder/builder/qop_connectivity/build_quam_wiring.py
@@ -43,10 +43,9 @@ def build_quam_wiring(
     machine = quam_instance
     add_ports_container(connectivity, machine)
     add_name_and_ip(machine, host_ip, cluster_name, port)
-    if dac_config is not None:
-        setter = getattr(machine, "set_dac_config", None)
-        if callable(setter):
-            setter(dac_config)
+    setter = getattr(machine, "set_dac_config", None)
+    if callable(setter):
+        setter(dac_config)
     machine.wiring = create_wiring(connectivity)
     machine.save(path)
     return machine

--- a/quam_builder/builder/qop_connectivity/create_wiring.py
+++ b/quam_builder/builder/qop_connectivity/create_wiring.py
@@ -18,6 +18,12 @@ from quam_builder.builder.qop_connectivity.create_digital_ports import (
     create_digital_output_port,
 )
 from quam_builder.builder.qop_connectivity.paths import *
+from quam_builder.builder.qop_connectivity.qdac_wiring import (
+    QDAC_OUTPUT_KEY,
+    QDAC_TRIGGER_KEY,
+    qdac_output_wiring_entry,
+    qdac_trigger_wiring_entry,
+)
 
 
 def create_wiring(connectivity: Connectivity) -> dict:
@@ -106,9 +112,9 @@ def qubit_wiring(
             key, reference = create_external_mixer_reference(channel, element_id, line_type)
             qubit_line_wiring[key] = reference
         elif isinstance(channel, InstrumentChannelQdac2Output):
-            qubit_line_wiring["qdac_channel"] = channel.port
+            qubit_line_wiring[QDAC_OUTPUT_KEY] = qdac_output_wiring_entry(channel)
         elif isinstance(channel, InstrumentChannelQdac2DigitalInput):
-            qubit_line_wiring["qdac_trigger_in"] = channel.port
+            qubit_line_wiring[QDAC_TRIGGER_KEY] = qdac_trigger_wiring_entry(channel)
         elif not (channel.signal_type == "digital" and channel.io_type == "input"):
             key, reference = get_channel_port(channel, channels)
             qubit_line_wiring[key] = reference
@@ -132,9 +138,9 @@ def qubit_pair_wiring(channels: List[AnyInstrumentChannel], element_id: QubitPai
     }
     for channel in channels:
         if isinstance(channel, InstrumentChannelQdac2Output):
-            qubit_pair_line_wiring["qdac_channel"] = channel.port
+            qubit_pair_line_wiring[QDAC_OUTPUT_KEY] = qdac_output_wiring_entry(channel)
         elif isinstance(channel, InstrumentChannelQdac2DigitalInput):
-            qubit_pair_line_wiring["qdac_trigger_in"] = channel.port
+            qubit_pair_line_wiring[QDAC_TRIGGER_KEY] = qdac_trigger_wiring_entry(channel)
         elif not (channel.signal_type == "digital" and channel.io_type == "input"):
             key, reference = get_channel_port(channel, channels)
             qubit_pair_line_wiring[key] = reference

--- a/quam_builder/builder/qop_connectivity/create_wiring.py
+++ b/quam_builder/builder/qop_connectivity/create_wiring.py
@@ -3,7 +3,11 @@ from functools import reduce
 from qualang_tools.wirer import Connectivity
 from qualang_tools.wirer.connectivity.element import QubitPairReference, QubitReference
 from qualang_tools.wirer.connectivity.wiring_spec import WiringLineType
-from qualang_tools.wirer.instruments.instrument_channel import AnyInstrumentChannel
+from qualang_tools.wirer.instruments.instrument_channel import (
+    AnyInstrumentChannel,
+    InstrumentChannelQdac2DigitalInput,
+    InstrumentChannelQdac2Output,
+)
 from quam_builder.builder.qop_connectivity.create_analog_ports import (
     create_octave_port,
     create_mw_fem_port,
@@ -101,6 +105,10 @@ def qubit_wiring(
         if channel.instrument_id == "external-mixer":
             key, reference = create_external_mixer_reference(channel, element_id, line_type)
             qubit_line_wiring[key] = reference
+        elif isinstance(channel, InstrumentChannelQdac2Output):
+            qubit_line_wiring["qdac_channel"] = channel.port
+        elif isinstance(channel, InstrumentChannelQdac2DigitalInput):
+            qubit_line_wiring["qdac_trigger_in"] = channel.port
         elif not (channel.signal_type == "digital" and channel.io_type == "input"):
             key, reference = get_channel_port(channel, channels)
             qubit_line_wiring[key] = reference
@@ -123,7 +131,11 @@ def qubit_pair_wiring(channels: List[AnyInstrumentChannel], element_id: QubitPai
         "target_qubit": f"{QUBITS_BASE_JSON_PATH}/q{element_id.target_index}",
     }
     for channel in channels:
-        if not (channel.signal_type == "digital" and channel.io_type == "input"):
+        if isinstance(channel, InstrumentChannelQdac2Output):
+            qubit_pair_line_wiring["qdac_channel"] = channel.port
+        elif isinstance(channel, InstrumentChannelQdac2DigitalInput):
+            qubit_pair_line_wiring["qdac_trigger_in"] = channel.port
+        elif not (channel.signal_type == "digital" and channel.io_type == "input"):
             key, reference = get_channel_port(channel, channels)
             qubit_pair_line_wiring[key] = reference
 

--- a/quam_builder/builder/qop_connectivity/create_wiring.py
+++ b/quam_builder/builder/qop_connectivity/create_wiring.py
@@ -18,6 +18,12 @@ from quam_builder.builder.qop_connectivity.create_digital_ports import (
     create_digital_output_port,
 )
 from quam_builder.builder.qop_connectivity.paths import *
+from quam_builder.builder.qop_connectivity.qdac_wiring import (
+    QDAC_OUTPUT_KEY,
+    QDAC_TRIGGER_KEY,
+    qdac_output_wiring_entry,
+    qdac_trigger_wiring_entry,
+)
 
 
 def create_wiring(connectivity: Connectivity) -> dict:
@@ -108,9 +114,9 @@ def qubit_wiring(
             )
             qubit_line_wiring[key] = reference
         elif isinstance(channel, InstrumentChannelQdac2Output):
-            qubit_line_wiring["qdac_channel"] = channel.port
+            qubit_line_wiring[QDAC_OUTPUT_KEY] = qdac_output_wiring_entry(channel)
         elif isinstance(channel, InstrumentChannelQdac2DigitalInput):
-            qubit_line_wiring["qdac_trigger_in"] = channel.port
+            qubit_line_wiring[QDAC_TRIGGER_KEY] = qdac_trigger_wiring_entry(channel)
         elif not (channel.signal_type == "digital" and channel.io_type == "input"):
             key, reference = get_channel_port(channel, channels)
             qubit_line_wiring[key] = reference
@@ -136,9 +142,9 @@ def qubit_pair_wiring(
     }
     for channel in channels:
         if isinstance(channel, InstrumentChannelQdac2Output):
-            qubit_pair_line_wiring["qdac_channel"] = channel.port
+            qubit_pair_line_wiring[QDAC_OUTPUT_KEY] = qdac_output_wiring_entry(channel)
         elif isinstance(channel, InstrumentChannelQdac2DigitalInput):
-            qubit_pair_line_wiring["qdac_trigger_in"] = channel.port
+            qubit_pair_line_wiring[QDAC_TRIGGER_KEY] = qdac_trigger_wiring_entry(channel)
         elif not (channel.signal_type == "digital" and channel.io_type == "input"):
             key, reference = get_channel_port(channel, channels)
             qubit_pair_line_wiring[key] = reference

--- a/quam_builder/builder/qop_connectivity/create_wiring.py
+++ b/quam_builder/builder/qop_connectivity/create_wiring.py
@@ -3,7 +3,11 @@ from functools import reduce
 from qualang_tools.wirer import Connectivity
 from qualang_tools.wirer.connectivity.element import QubitPairReference, QubitReference
 from qualang_tools.wirer.connectivity.wiring_spec import WiringLineType
-from qualang_tools.wirer.instruments.instrument_channel import AnyInstrumentChannel
+from qualang_tools.wirer.instruments.instrument_channel import (
+    AnyInstrumentChannel,
+    InstrumentChannelQdac2DigitalInput,
+    InstrumentChannelQdac2Output,
+)
 from quam_builder.builder.qop_connectivity.create_analog_ports import (
     create_octave_port,
     create_mw_fem_port,
@@ -103,6 +107,10 @@ def qubit_wiring(
                 channel, element_id, line_type
             )
             qubit_line_wiring[key] = reference
+        elif isinstance(channel, InstrumentChannelQdac2Output):
+            qubit_line_wiring["qdac_channel"] = channel.port
+        elif isinstance(channel, InstrumentChannelQdac2DigitalInput):
+            qubit_line_wiring["qdac_trigger_in"] = channel.port
         elif not (channel.signal_type == "digital" and channel.io_type == "input"):
             key, reference = get_channel_port(channel, channels)
             qubit_line_wiring[key] = reference
@@ -127,7 +135,11 @@ def qubit_pair_wiring(
         "target_qubit": f"{QUBITS_BASE_JSON_PATH}/q{element_id.target_index}",
     }
     for channel in channels:
-        if not (channel.signal_type == "digital" and channel.io_type == "input"):
+        if isinstance(channel, InstrumentChannelQdac2Output):
+            qubit_pair_line_wiring["qdac_channel"] = channel.port
+        elif isinstance(channel, InstrumentChannelQdac2DigitalInput):
+            qubit_pair_line_wiring["qdac_trigger_in"] = channel.port
+        elif not (channel.signal_type == "digital" and channel.io_type == "input"):
             key, reference = get_channel_port(channel, channels)
             qubit_pair_line_wiring[key] = reference
 

--- a/quam_builder/builder/qop_connectivity/get_digital_outputs.py
+++ b/quam_builder/builder/qop_connectivity/get_digital_outputs.py
@@ -16,13 +16,21 @@ def get_digital_outputs(
         dict[str, DigitalOutputChannel]: A dictionary of digital output channels.
     """
     digital_outputs = dict()
-    for i, item in enumerate([port for port in ports if "digital_output" in port]):
+    digital_output_ports = [port for port in ports if "digital_output" in port]
+    num_digital_output_ports = len(digital_output_ports)
+
+    for i, item in enumerate(digital_output_ports):
+        key = (
+            digital_marker_name
+            if num_digital_output_ports == 1
+            else f"{digital_marker_name}_{i}"
+        )
         if digital_marker_name == "octave_switch":
             if isinstance(
                 DigitalOutputChannel(opx_output=f"{wiring_path}/{item}").opx_output,
                 FEMDigitalOutputPort,
             ):
-                digital_outputs[f"{digital_marker_name}_{i}"] = DigitalOutputChannel(
+                digital_outputs[key] = DigitalOutputChannel(
                     opx_output=f"{wiring_path}/{item}",
                     delay=14,  # 14ns for QOP333 and above
                     buffer=13,  # 13ns for QOP333 and above
@@ -31,13 +39,13 @@ def get_digital_outputs(
                 DigitalOutputChannel(opx_output=f"{wiring_path}/{item}").opx_output,
                 OPXPlusDigitalOutputPort,
             ):
-                digital_outputs[f"{digital_marker_name}_{i}"] = DigitalOutputChannel(
+                digital_outputs[key] = DigitalOutputChannel(
                     opx_output=f"{wiring_path}/{item}",
                     delay=57,  # 57ns for QOP222 and above
                     buffer=18,  # 18ns for QOP222 and above
                 )
         else:
-            digital_outputs[f"{digital_marker_name}_{i}"] = DigitalOutputChannel(
+            digital_outputs[key] = DigitalOutputChannel(
                 opx_output=f"{wiring_path}/{item}",
                 delay=0,
                 buffer=0,

--- a/quam_builder/builder/qop_connectivity/qdac_wiring.py
+++ b/quam_builder/builder/qop_connectivity/qdac_wiring.py
@@ -1,10 +1,11 @@
 """QDAC-II wiring helpers (quam-builder only; no QUAM fork).
 
-QUAM resolves ``#/ports/...`` strings via :meth:`FEMPortsContainer.reference_to_port` /
-:class:`OPXPlusPortsContainer`, which only understand OPX1000 / OPX+ layouts. QDAC outputs are
-external to that graph, so we use a **parallel** reference root ``#/qdac/...`` plus explicit
-``unit_index`` and ``port`` fields. That keeps ``wiring.json`` readable for multi-unit setups
-without registering fake entries under ``machine.ports``.
+QUAM resolves any string starting with ``#/`` as a JSON pointer into the Quam root (see
+:func:`quam.utils.string_reference.is_reference`). QDAC outputs are not components on the root,
+so there is no live ``#/qdac/...`` target to resolve. We therefore store **logical** ids in
+``ref`` **without** a ``#/`` prefix (e.g. ``qdac/analog_outputs/qdac1/3``) so traversal of
+``machine.wiring`` does not emit missing-reference warnings. Use ``unit_index`` and ``port``
+for programmatic use; ``ref`` is for humans and external tooling.
 """
 
 from __future__ import annotations
@@ -34,13 +35,13 @@ QDAC_TRIGGER_KEY = "qdac_trigger"
 
 
 def qdac_analog_output_ref(unit_index: int, port: int) -> str:
-    """Stable JSON-pointer-style id for a QDAC DC output (not under ``#/ports``)."""
-    return f"#/qdac/analog_outputs/qdac{int(unit_index)}/{int(port)}"
+    """Stable logical path for a QDAC DC output (not a QUAM ``#/`` reference)."""
+    return f"qdac/analog_outputs/qdac{int(unit_index)}/{int(port)}"
 
 
 def qdac_digital_input_ref(unit_index: int, port: int) -> str:
-    """Stable id for a QDAC external trigger input (not under ``#/ports``)."""
-    return f"#/qdac/digital_inputs/qdac{int(unit_index)}/{int(port)}"
+    """Stable logical path for a QDAC external trigger input (not a QUAM ``#/`` reference)."""
+    return f"qdac/digital_inputs/qdac{int(unit_index)}/{int(port)}"
 
 
 def qdac_output_wiring_entry(channel: InstrumentChannelQdac2Output) -> Dict[str, Any]:

--- a/quam_builder/builder/qop_connectivity/qdac_wiring.py
+++ b/quam_builder/builder/qop_connectivity/qdac_wiring.py
@@ -1,0 +1,111 @@
+"""QDAC-II wiring helpers (quam-builder only; no QUAM fork).
+
+QUAM resolves ``#/ports/...`` strings via :meth:`FEMPortsContainer.reference_to_port` /
+:class:`OPXPlusPortsContainer`, which only understand OPX1000 / OPX+ layouts. QDAC outputs are
+external to that graph, so we use a **parallel** reference root ``#/qdac/...`` plus explicit
+``unit_index`` and ``port`` fields. That keeps ``wiring.json`` readable for multi-unit setups
+without registering fake entries under ``machine.ports``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional
+
+from qualang_tools.wirer.instruments.instrument_channel import (
+    InstrumentChannelQdac2DigitalInput,
+    InstrumentChannelQdac2Output,
+)
+
+__all__ = [
+    "QDAC_OUTPUT_KEY",
+    "QDAC_TRIGGER_KEY",
+    "qdac_analog_output_ref",
+    "qdac_digital_input_ref",
+    "qdac_output_wiring_entry",
+    "qdac_trigger_wiring_entry",
+    "extract_qdac_output_port",
+    "extract_qdac_unit_index",
+    "extract_qdac_trigger_port",
+    "extract_qdac_trigger_unit_index",
+]
+
+QDAC_OUTPUT_KEY = "qdac_output"
+QDAC_TRIGGER_KEY = "qdac_trigger"
+
+
+def qdac_analog_output_ref(unit_index: int, port: int) -> str:
+    """Stable JSON-pointer-style id for a QDAC DC output (not under ``#/ports``)."""
+    return f"#/qdac/analog_outputs/qdac{int(unit_index)}/{int(port)}"
+
+
+def qdac_digital_input_ref(unit_index: int, port: int) -> str:
+    """Stable id for a QDAC external trigger input (not under ``#/ports``)."""
+    return f"#/qdac/digital_inputs/qdac{int(unit_index)}/{int(port)}"
+
+
+def qdac_output_wiring_entry(channel: InstrumentChannelQdac2Output) -> Dict[str, Any]:
+    u, p = int(channel.con), int(channel.port)
+    return {
+        "unit_index": u,
+        "port": p,
+        "ref": qdac_analog_output_ref(u, p),
+    }
+
+
+def qdac_trigger_wiring_entry(channel: InstrumentChannelQdac2DigitalInput) -> Dict[str, Any]:
+    u, p = int(channel.con), int(channel.port)
+    return {
+        "unit_index": u,
+        "port": p,
+        "ref": qdac_digital_input_ref(u, p),
+    }
+
+
+def extract_qdac_output_port(wiring_dict: Mapping[str, Any]) -> Optional[int]:
+    """Analog output port (1–24) on the QDAC unit, or ``None``."""
+    block = wiring_dict.get(QDAC_OUTPUT_KEY)
+    if isinstance(block, Mapping):
+        port = block.get("port")
+        if port is not None:
+            return int(port)
+    legacy = wiring_dict.get("qdac_channel")
+    if isinstance(legacy, int):
+        return legacy
+    if isinstance(legacy, Mapping) and legacy.get("port") is not None:
+        return int(legacy["port"])
+    return None
+
+
+def extract_qdac_unit_index(wiring_dict: Mapping[str, Any]) -> Optional[int]:
+    """Wirer ``con`` / QDAC unit index if present."""
+    block = wiring_dict.get(QDAC_OUTPUT_KEY)
+    if isinstance(block, Mapping):
+        u = block.get("unit_index")
+        if u is not None:
+            return int(u)
+    legacy = wiring_dict.get("qdac_channel")
+    if isinstance(legacy, Mapping) and legacy.get("unit_index") is not None:
+        return int(legacy["unit_index"])
+    return None
+
+
+def extract_qdac_trigger_port(wiring_dict: Mapping[str, Any]) -> Optional[int]:
+    """External trigger input port (1–4), or ``None``."""
+    block = wiring_dict.get(QDAC_TRIGGER_KEY)
+    if isinstance(block, Mapping):
+        port = block.get("port")
+        if port is not None:
+            return int(port)
+    legacy = wiring_dict.get("qdac_trigger_in")
+    if isinstance(legacy, int):
+        return legacy
+    return None
+
+
+def extract_qdac_trigger_unit_index(wiring_dict: Mapping[str, Any]) -> Optional[int]:
+    block = wiring_dict.get(QDAC_TRIGGER_KEY)
+    if isinstance(block, Mapping):
+        u = block.get("unit_index")
+        if u is not None:
+            return int(u)
+    return None

--- a/quam_builder/builder/quantum_dots/build_quam.py
+++ b/quam_builder/builder/quantum_dots/build_quam.py
@@ -350,14 +350,15 @@ def add_ports(machine: AnyQuamQD) -> None:
     Args:
         machine: QuAM instance with wiring defined.
     """
+    if machine.ports is None:
+        return
     for wiring_by_element in machine.wiring.values():
         for wiring_by_line_type in wiring_by_element.values():
             for ports in wiring_by_line_type.values():
                 for port in ports:
-                    if "ports" in ports.get_unreferenced_value(port):
-                        machine.ports.reference_to_port(
-                            ports.get_unreferenced_value(port), create=True
-                        )
+                    raw = ports.get_unreferenced_value(port)
+                    if isinstance(raw, str) and "ports" in raw:
+                        machine.ports.reference_to_port(raw, create=True)
 
 
 def add_qpu(machine: AnyQuamQD, qubit_pair_sensor_map: Optional[dict] = None) -> None:

--- a/quam_builder/builder/quantum_dots/build_quam.py
+++ b/quam_builder/builder/quantum_dots/build_quam.py
@@ -686,5 +686,4 @@ def add_dacs(
                 with_trigger_channel=bool(entry.get("trigger", False)),
                 digital_output_key=digital_output_key,
                 qdac_trigger_in=entry_qti,
-                trigger_pulse_length_ns=trigger_pulse_length_ns,
-            )
+remove trigger pulse length            )

--- a/quam_builder/builder/quantum_dots/build_quam.py
+++ b/quam_builder/builder/quantum_dots/build_quam.py
@@ -617,7 +617,7 @@ def _wire_voltage_gate_qdac(
         with_trigger_channel: If True, move ``digital_output_key`` into a wrapper
             ``Channel`` referenced by ``QdacSpec.opx_trigger_out``.
         digital_output_key: Name of the digital output on the gate (default wiring
-            uses ``qdac_trig_0``).
+            uses ``qdac_trig``).
         qdac_trigger_in: Optional QDAC external trigger port.
         trigger_pulse_length_ns: Length of the default ``trigger`` pulse on the
             wrapper channel when ``with_trigger_channel`` is True.
@@ -645,7 +645,7 @@ def _wire_voltage_gate_qdac(
 def add_dacs(
     machine: BaseQuamQD,
     *,
-    digital_output_key: str = "qdac_trig_0",
+    digital_output_key: str = "qdac_trig",
     dac_name: str = "qdac",
     qdac_trigger_in: Optional[int] = None,
     trigger_pulse_length_ns: int = 100,

--- a/quam_builder/builder/quantum_dots/build_quam.py
+++ b/quam_builder/builder/quantum_dots/build_quam.py
@@ -17,6 +17,15 @@ from pathlib import Path
 from typing import Optional, Union, Mapping, Any
 
 from qualang_tools.wirer.connectivity.wiring_spec import WiringLineType
+from quam_builder.builder.quantum_dots.build_utils import (
+    _extract_qubit_number,
+    _normalize_element_type,
+)
+from quam_builder.builder.qop_connectivity.qdac_wiring import (
+    extract_qdac_output_port,
+    extract_qdac_trigger_port,
+    extract_qdac_unit_index,
+)
 from quam.components import FrequencyConverter, LocalOscillator, Octave
 from quam_builder.architecture.superconducting.components.mixer import StandaloneMixer
 from quam_builder.builder.quantum_dots.build_qpu import (
@@ -30,10 +39,104 @@ from quam_builder.architecture.quantum_dots.qpu import BaseQuamQD, LossDiVincenz
 from quam_builder.architecture.quantum_dots.macro_engine import wire_machine_macros
 from quam_builder.architecture.quantum_dots.components import VoltageGate, QdacSpec
 
+
+def _to_plain_mapping(obj: Any, max_depth: int = 6) -> Any:
+    """Recursively unwrap QUAM wiring containers into plain dict/list structures."""
+    if max_depth <= 0:
+        return obj
+    if obj is None or isinstance(obj, (str, bytes, int, float, bool)):
+        return obj
+    if isinstance(obj, Mapping):
+        return {k: _to_plain_mapping(v, max_depth - 1) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return type(obj)(_to_plain_mapping(x, max_depth - 1) for x in obj)
+    if hasattr(obj, "get_unreferenced_value") and hasattr(obj, "keys"):
+        return {
+            k: _to_plain_mapping(obj.get_unreferenced_value(k), max_depth - 1)
+            for k in obj.keys()
+        }
+    return obj
+
+
+def _dac_entry_from_wiring_plain(plain: Mapping[str, Any]) -> Optional[dict[str, Any]]:
+    """Build one :func:`add_dacs` entry from flattened port mapping, or ``None`` if no QDAC DC port."""
+    ch = extract_qdac_output_port(plain)
+    if ch is None:
+        return None
+    trigger = any("digital_output" in str(k) for k in plain)
+    qti = extract_qdac_trigger_port(plain)
+    u = extract_qdac_unit_index(plain)
+    dac_name = "qdac" if u is None else f"qdac{u}"
+    return {
+        "ch": ch,
+        "trigger": trigger,
+        "qdac_trigger_in": qti,
+        "dac_name": dac_name,
+    }
+
+
+def _dac_mapping_from_wiring(machine: BaseQuamQD) -> dict[str, dict[str, Any]]:
+    """Mirror :class:`_BaseQpuBuilder` gate ids and barrier ordering from ``machine.wiring``."""
+    wiring = machine.wiring or {}
+    normalized: dict[str, Any] = {}
+    for element_type_raw, elements in wiring.items():
+        et = _normalize_element_type(element_type_raw)
+        if et:
+            normalized[et] = elements
+
+    result: dict[str, dict[str, Any]] = {}
+
+    for global_id, wiring_by_line_type in normalized.get("globals", {}).items():
+        for _line_type, ports in wiring_by_line_type.items():
+            plain = _to_plain_mapping(ports)
+            if not isinstance(plain, dict):
+                continue
+            entry = _dac_entry_from_wiring_plain(plain)
+            if entry:
+                result[global_id] = entry
+
+    for sensor_id, wiring_by_line_type in normalized.get("readout", {}).items():
+        sensor_gate_id = f"sensor_{_extract_qubit_number(sensor_id)}"
+        for line_type, ports in wiring_by_line_type.items():
+            if line_type != WiringLineType.SENSOR_GATE.value:
+                continue
+            plain = _to_plain_mapping(ports)
+            if not isinstance(plain, dict):
+                continue
+            entry = _dac_entry_from_wiring_plain(plain)
+            if entry:
+                result[sensor_gate_id] = entry
+
+    for qubit_id, wiring_by_line_type in normalized.get("qubits", {}).items():
+        for line_type, ports in wiring_by_line_type.items():
+            if line_type != WiringLineType.PLUNGER_GATE.value:
+                continue
+            plain = _to_plain_mapping(ports)
+            if not isinstance(plain, dict):
+                continue
+            entry = _dac_entry_from_wiring_plain(plain)
+            if entry:
+                result[f"plunger_{_extract_qubit_number(qubit_id)}"] = entry
+
+    barrier_counter = 0
+    for _pair_id, wiring_by_line_type in normalized.get("qubit_pairs", {}).items():
+        for line_type, ports in wiring_by_line_type.items():
+            if line_type != WiringLineType.BARRIER_GATE.value:
+                continue
+            plain = _to_plain_mapping(ports)
+            if not isinstance(plain, dict):
+                continue
+            entry = _dac_entry_from_wiring_plain(plain)
+            if entry:
+                result[f"barrier_{barrier_counter}"] = entry
+            barrier_counter += 1
+
+    return result
+
+
 def build_base_quam(
     machine: BaseQuamQD,
     calibration_db_path: Optional[Union[Path, str]] = None,
-    dac_mapping: Optional[dict] = None,
     connect_qdac: bool = False,
     macro_profile_path: Optional[Union[Path, str]] = None,
     component_overrides: Optional[dict] = None,
@@ -59,7 +162,6 @@ def build_base_quam(
         machine: BaseQuamQD instance with wiring defined.
         calibration_db_path: Path to Octave calibration database. If None, uses
             the machine's state directory.
-        dac_mapping: mapping between the voltage gate and the corresponding dac channel {"voltage_gate_name": {"ch": dac_channel_number, "trigger": bool}}
         connect_qdac: If True, connects to QDAC using qdac_ip or machine.network['qdac_ip'].
         macro_profile_path: Optional TOML file with macro override definitions.
         component_overrides: Typed overrides keyed by component class. See
@@ -92,8 +194,8 @@ def build_base_quam(
     _BaseQpuBuilder(machine).build()
     if getattr(machine, "qpu", None) is None:
         machine.qpu = QPU()
-    # Map the connectivity between the DAC channels of the voltage gates
-    add_dacs(machine, dac_mapping)
+    # Map QDAC output ports from machine.wiring onto VoltageGate.dac_spec
+    add_dacs(machine)
 
     wire_machine_macros(
         machine,
@@ -229,7 +331,6 @@ def build_quam(
     machine: Union[BaseQuamQD, LossDiVincenzoQuam],
     calibration_db_path: Optional[Union[Path, str]] = None,
     qubit_pair_sensor_map: Optional[dict] = None,
-    dac_mapping: Optional[dict] = None,
     connect_qdac: bool = False,
     macro_profile_path: Optional[Union[Path, str]] = None,
     component_overrides: Optional[dict] = None,
@@ -248,7 +349,6 @@ def build_quam(
         machine: BaseQuamQD or LossDiVincenzoQuam with wiring defined.
         calibration_db_path: Path to Octave calibration database.
         qubit_pair_sensor_map: Sensor mapping for qubit pairs.
-        dac_mapping: mapping between the voltage gate and the corresponding dac channel {"voltage_gate_name": {"ch": dac_channel_number, "trigger": bool}}
         connect_qdac: If True, connects to QDAC for external voltage control.
         macro_profile_path: Optional TOML file with macro override definitions.
         component_overrides: Typed overrides keyed by component class. See
@@ -281,7 +381,6 @@ def build_quam(
         machine = build_base_quam(
             machine,
             calibration_db_path=calibration_db_path,
-            dac_mapping=dac_mapping,
             connect_qdac=connect_qdac,
             macro_profile_path=macro_profile_path,
             component_overrides=component_overrides,
@@ -500,9 +599,8 @@ def _wire_voltage_gate_qdac(
     qdac_output_port: int,
     dac_name: str = "qdac",
     with_trigger_channel: bool = False,
-    digital_output_key: str = "qdac_trig_0",
+    digital_output_key: str = "qdac_trig",
     qdac_trigger_in: Optional[int] = None,
-    trigger_pulse_length_ns: int = 100,
 ) -> None:
     """Attach QDAC metadata and optionally move a digital trigger under a wrapper ``Channel``.
 
@@ -531,66 +629,62 @@ def _wire_voltage_gate_qdac(
                 f"{getattr(voltage_gate, 'name', voltage_gate)!r}"
             )
         dig = voltage_gate.digital_outputs[digital_output_key]
-        # digital_ch = Channel(
-        #     id=f"qdac_trig_{qdac_output_port}",
-        #     digital_outputs={},
-        #     operations={
-        #         "trigger": pulses.Pulse(
-        #             length=trigger_pulse_length_ns, digital_marker="ON"
-        #         )
-        #     },
-        # )
         voltage_gate.dac_spec = QdacSpec(
             dac_name=dac_name,
             qdac_output_port=qdac_output_port,
             opx_trigger_out=dig.opx_output.get_reference(),
             qdac_trigger_in=qdac_trigger_in,
         )
-        # del voltage_gate.digital_outputs[digital_output_key]
-        # dig.parent = None
-        # digital_ch.digital_outputs["trigger"] = dig
     else:
         voltage_gate.dac_spec = QdacSpec(
             dac_name=dac_name,
             qdac_output_port=qdac_output_port,
         )
 
+
 def add_dacs(
     machine: BaseQuamQD,
-    dac_mapping: Mapping[str, Mapping[str, Any]],
     *,
     digital_output_key: str = "qdac_trig_0",
     dac_name: str = "qdac",
     qdac_trigger_in: Optional[int] = None,
     trigger_pulse_length_ns: int = 100,
 ) -> None:
-    """Apply :meth:`wire_voltage_gate_qdac` to every ``VoltageGate`` listed in ``qdac_mapping``.
+    """Attach ``QdacSpec`` to gates using QDAC ports from ``machine.wiring``.
 
-    Keys of ``qdac_mapping`` must match :attr:`VoltageGate.name` (same as the prior
-    ``quam_config`` loop). Values are dicts with at least ``"ch"`` (QDAC port index,
-    or ``None`` to skip) and optional ``"trigger"`` (bool, default ``False``).
-
-    Channel entries are resolved via ``virtual_gate_sets[gate_set_id].channels[key]``
-    so ``#/`` references are followed while the gate set is already under this root.
+    Uses :func:`_dac_mapping_from_wiring`. No-op when wiring defines no QDAC DC outputs.
     """
+    by_gate = _dac_mapping_from_wiring(machine)
+    if not by_gate:
+        return
     for vgs_key in machine.virtual_gate_sets.keys():
         vgs = machine.virtual_gate_sets[vgs_key]
         for channel_name in list(vgs.channels.keys()):
             gate = vgs.channels[channel_name]
             if not isinstance(gate, VoltageGate):
                 continue
-            if gate.name not in dac_mapping:
+            entry = None
+            for cand in (
+                channel_name,
+                getattr(gate, "id", None),
+                getattr(gate, "name", None),
+            ):
+                if cand and cand in by_gate:
+                    entry = by_gate[cand]
+                    break
+            if entry is None:
                 continue
-            entry = dac_mapping[gate.name]
             ch_nb = entry.get("ch")
             if ch_nb is None:
                 continue
+            entry_dac = entry.get("dac_name", dac_name)
+            entry_qti = entry.get("qdac_trigger_in", qdac_trigger_in)
             _wire_voltage_gate_qdac(
                 gate,
                 qdac_output_port=ch_nb,
-                dac_name=dac_name,
+                dac_name=entry_dac,
                 with_trigger_channel=bool(entry.get("trigger", False)),
                 digital_output_key=digital_output_key,
-                qdac_trigger_in=qdac_trigger_in,
+                qdac_trigger_in=entry_qti,
                 trigger_pulse_length_ns=trigger_pulse_length_ns,
             )

--- a/quam_builder/builder/quantum_dots/build_quam.py
+++ b/quam_builder/builder/quantum_dots/build_quam.py
@@ -686,4 +686,4 @@ def add_dacs(
                 with_trigger_channel=bool(entry.get("trigger", False)),
                 digital_output_key=digital_output_key,
                 qdac_trigger_in=entry_qti,
-remove trigger pulse length            )
+            )

--- a/quam_builder/builder/quantum_dots/build_quam.py
+++ b/quam_builder/builder/quantum_dots/build_quam.py
@@ -352,21 +352,20 @@ def add_ports(machine: AnyQuamQD) -> None:
     Args:
         machine: QuAM instance with wiring defined.
     """
+    if machine.ports is None:
+        return
     for wiring_by_element in machine.wiring.values():
         for wiring_by_line_type in wiring_by_element.values():
             for line_type, ports in wiring_by_line_type.items():
                 for port in ports:
-                    port_ref = ports.get_unreferenced_value(port)
-                    if "ports" in port_ref:
-                        created_port = machine.ports.reference_to_port(
-                            port_ref, create=True
-                        )
+                    raw = ports.get_unreferenced_value(port)
+                    if isinstance(raw, str) and "ports" in raw:
+                        created_port = machine.ports.reference_to_port(raw, create=True)
                         if (
                             hasattr(created_port, "upsampling_mode")
                             and line_type not in _RF_LINE_TYPES
                         ):
                             created_port.upsampling_mode = "pulse"
-
 
 def add_qpu(machine: AnyQuamQD, qubit_pair_sensor_map: Optional[dict] = None) -> None:
     """Build and register QPU elements from wiring specifications.

--- a/quam_builder/builder/quantum_dots/build_quam.py
+++ b/quam_builder/builder/quantum_dots/build_quam.py
@@ -701,5 +701,4 @@ def add_dacs(
                 with_trigger_channel=bool(entry.get("trigger", False)),
                 digital_output_key=digital_output_key,
                 qdac_trigger_in=entry_qti,
-                trigger_pulse_length_ns=trigger_pulse_length_ns,
-            )
+remove trigger pulse length            )

--- a/quam_builder/builder/quantum_dots/build_quam.py
+++ b/quam_builder/builder/quantum_dots/build_quam.py
@@ -701,4 +701,4 @@ def add_dacs(
                 with_trigger_channel=bool(entry.get("trigger", False)),
                 digital_output_key=digital_output_key,
                 qdac_trigger_in=entry_qti,
-remove trigger pulse length            )
+            )

--- a/quam_builder/builder/quantum_dots/build_quam.py
+++ b/quam_builder/builder/quantum_dots/build_quam.py
@@ -17,6 +17,15 @@ from pathlib import Path
 from typing import Mapping, Optional, Sequence, Union, Any
 
 from qualang_tools.wirer.connectivity.wiring_spec import WiringLineType
+from quam_builder.builder.quantum_dots.build_utils import (
+    _extract_qubit_number,
+    _normalize_element_type,
+)
+from quam_builder.builder.qop_connectivity.qdac_wiring import (
+    extract_qdac_output_port,
+    extract_qdac_trigger_port,
+    extract_qdac_unit_index,
+)
 from quam.components import FrequencyConverter, LocalOscillator, Octave
 from quam_builder.architecture.superconducting.components.mixer import StandaloneMixer
 from quam_builder.builder.quantum_dots.build_qpu import (
@@ -37,10 +46,104 @@ from quam_builder.architecture.quantum_dots.components import VoltageGate, QdacS
 from quam_builder.architecture.superconducting.qpu import AnyQuam
 
 
+
+def _to_plain_mapping(obj: Any, max_depth: int = 6) -> Any:
+    """Recursively unwrap QUAM wiring containers into plain dict/list structures."""
+    if max_depth <= 0:
+        return obj
+    if obj is None or isinstance(obj, (str, bytes, int, float, bool)):
+        return obj
+    if isinstance(obj, Mapping):
+        return {k: _to_plain_mapping(v, max_depth - 1) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return type(obj)(_to_plain_mapping(x, max_depth - 1) for x in obj)
+    if hasattr(obj, "get_unreferenced_value") and hasattr(obj, "keys"):
+        return {
+            k: _to_plain_mapping(obj.get_unreferenced_value(k), max_depth - 1)
+            for k in obj.keys()
+        }
+    return obj
+
+
+def _dac_entry_from_wiring_plain(plain: Mapping[str, Any]) -> Optional[dict[str, Any]]:
+    """Build one :func:`add_dacs` entry from flattened port mapping, or ``None`` if no QDAC DC port."""
+    ch = extract_qdac_output_port(plain)
+    if ch is None:
+        return None
+    trigger = any("digital_output" in str(k) for k in plain)
+    qti = extract_qdac_trigger_port(plain)
+    u = extract_qdac_unit_index(plain)
+    dac_name = "qdac" if u is None else f"qdac{u}"
+    return {
+        "ch": ch,
+        "trigger": trigger,
+        "qdac_trigger_in": qti,
+        "dac_name": dac_name,
+    }
+
+
+def _dac_mapping_from_wiring(machine: BaseQuamQD) -> dict[str, dict[str, Any]]:
+    """Mirror :class:`_BaseQpuBuilder` gate ids and barrier ordering from ``machine.wiring``."""
+    wiring = machine.wiring or {}
+    normalized: dict[str, Any] = {}
+    for element_type_raw, elements in wiring.items():
+        et = _normalize_element_type(element_type_raw)
+        if et:
+            normalized[et] = elements
+
+    result: dict[str, dict[str, Any]] = {}
+
+    for global_id, wiring_by_line_type in normalized.get("globals", {}).items():
+        for _line_type, ports in wiring_by_line_type.items():
+            plain = _to_plain_mapping(ports)
+            if not isinstance(plain, dict):
+                continue
+            entry = _dac_entry_from_wiring_plain(plain)
+            if entry:
+                result[global_id] = entry
+
+    for sensor_id, wiring_by_line_type in normalized.get("readout", {}).items():
+        sensor_gate_id = f"sensor_{_extract_qubit_number(sensor_id)}"
+        for line_type, ports in wiring_by_line_type.items():
+            if line_type != WiringLineType.SENSOR_GATE.value:
+                continue
+            plain = _to_plain_mapping(ports)
+            if not isinstance(plain, dict):
+                continue
+            entry = _dac_entry_from_wiring_plain(plain)
+            if entry:
+                result[sensor_gate_id] = entry
+
+    for qubit_id, wiring_by_line_type in normalized.get("qubits", {}).items():
+        for line_type, ports in wiring_by_line_type.items():
+            if line_type != WiringLineType.PLUNGER_GATE.value:
+                continue
+            plain = _to_plain_mapping(ports)
+            if not isinstance(plain, dict):
+                continue
+            entry = _dac_entry_from_wiring_plain(plain)
+            if entry:
+                result[f"plunger_{_extract_qubit_number(qubit_id)}"] = entry
+
+    barrier_counter = 0
+    for _pair_id, wiring_by_line_type in normalized.get("qubit_pairs", {}).items():
+        for line_type, ports in wiring_by_line_type.items():
+            if line_type != WiringLineType.BARRIER_GATE.value:
+                continue
+            plain = _to_plain_mapping(ports)
+            if not isinstance(plain, dict):
+                continue
+            entry = _dac_entry_from_wiring_plain(plain)
+            if entry:
+                result[f"barrier_{barrier_counter}"] = entry
+            barrier_counter += 1
+
+    return result
+
+
 def build_base_quam(
     machine: BaseQuamQD,
     calibration_db_path: Optional[Union[Path, str]] = None,
-    qdac_ip: Optional[str] = None,
     connect_qdac: bool = False,
     catalogs: Optional[Sequence[MacroCatalog]] = None,
     instance_overrides: Optional[dict[str, MacroFactoryMap]] = None,
@@ -66,8 +169,6 @@ def build_base_quam(
         machine: BaseQuamQD instance with wiring defined.
         calibration_db_path: Path to Octave calibration database. If None, uses
             the machine's state directory.
-        qdac_ip: IP address for QDAC connection. If provided with connect_qdac=True,
-            connects to QDAC for external voltage control.
         connect_qdac: If True, connects to QDAC using qdac_ip or machine.network['qdac_ip'].
         catalogs: Optional list of ``MacroCatalog`` instances (e.g. lab packages).
         instance_overrides: Per-component-path overrides keyed by path string.
@@ -101,12 +202,18 @@ def build_base_quam(
 
     if getattr(machine, "qpu", None) is None:
         machine.qpu = QPU()
+    # Map QDAC output ports from machine.wiring onto VoltageGate.dac_spec
+    add_dacs(machine)
+
+    wire_machine_macros(
+        machine,
+        catalogs=catalogs,
+        instance_overrides=instance_overrides,
+    )
 
     # Optional QDAC connection
     if connect_qdac:
-        if qdac_ip:
-            machine.network["qdac_ip"] = qdac_ip
-        machine.connect_to_external_source(external_qdac=True)
+        machine.connect_to_external_source()
 
     if save:
         machine.save(path)
@@ -225,7 +332,6 @@ def build_quam(
     machine: Union[BaseQuamQD, LossDiVincenzoQuam],
     calibration_db_path: Optional[Union[Path, str]] = None,
     qubit_pair_sensor_map: Optional[dict] = None,
-    qdac_ip: Optional[str] = None,
     connect_qdac: bool = False,
     catalogs: Optional[Sequence[MacroCatalog]] = None,
     instance_overrides: Optional[dict[str, MacroFactoryMap]] = None,
@@ -246,7 +352,6 @@ def build_quam(
         machine: BaseQuamQD or LossDiVincenzoQuam with wiring defined.
         calibration_db_path: Path to Octave calibration database.
         qubit_pair_sensor_map: Sensor mapping for qubit pairs.
-        qdac_ip: IP address for QDAC connection.
         connect_qdac: If True, connects to QDAC for external voltage control.
         catalogs: Optional list of ``MacroCatalog`` instances (e.g. lab packages).
         instance_overrides: Per-component-path overrides keyed by path string.
@@ -279,7 +384,6 @@ def build_quam(
         machine = build_base_quam(
             machine,
             calibration_db_path=calibration_db_path,
-            qdac_ip=qdac_ip,
             connect_qdac=connect_qdac,
             catalogs=catalogs,
             instance_overrides=instance_overrides,
@@ -510,9 +614,8 @@ def _wire_voltage_gate_qdac(
     qdac_output_port: int,
     dac_name: str = "qdac",
     with_trigger_channel: bool = False,
-    digital_output_key: str = "qdac_trig_0",
+    digital_output_key: str = "qdac_trig",
     qdac_trigger_in: Optional[int] = None,
-    trigger_pulse_length_ns: int = 100,
 ) -> None:
     """Attach QDAC metadata and optionally move a digital trigger under a wrapper ``Channel``.
 
@@ -541,24 +644,12 @@ def _wire_voltage_gate_qdac(
                 f"{getattr(voltage_gate, 'name', voltage_gate)!r}"
             )
         dig = voltage_gate.digital_outputs[digital_output_key]
-        # digital_ch = Channel(
-        #     id=f"qdac_trig_{qdac_output_port}",
-        #     digital_outputs={},
-        #     operations={
-        #         "trigger": pulses.Pulse(
-        #             length=trigger_pulse_length_ns, digital_marker="ON"
-        #         )
-        #     },
-        # )
         voltage_gate.dac_spec = QdacSpec(
             dac_name=dac_name,
             qdac_output_port=qdac_output_port,
             opx_trigger_out=dig.opx_output.get_reference(),
             qdac_trigger_in=qdac_trigger_in,
         )
-        # del voltage_gate.digital_outputs[digital_output_key]
-        # dig.parent = None
-        # digital_ch.digital_outputs["trigger"] = dig
     else:
         voltage_gate.dac_spec = QdacSpec(
             dac_name=dac_name,
@@ -568,40 +659,47 @@ def _wire_voltage_gate_qdac(
 
 def add_dacs(
     machine: BaseQuamQD,
-    dac_mapping: Mapping[str, Mapping[str, Any]],
     *,
     digital_output_key: str = "qdac_trig_0",
     dac_name: str = "qdac",
     qdac_trigger_in: Optional[int] = None,
     trigger_pulse_length_ns: int = 100,
 ) -> None:
-    """Apply :meth:`wire_voltage_gate_qdac` to every ``VoltageGate`` listed in ``qdac_mapping``.
+    """Attach ``QdacSpec`` to gates using QDAC ports from ``machine.wiring``.
 
-    Keys of ``qdac_mapping`` must match :attr:`VoltageGate.name` (same as the prior
-    ``quam_config`` loop). Values are dicts with at least ``"ch"`` (QDAC port index,
-    or ``None`` to skip) and optional ``"trigger"`` (bool, default ``False``).
-
-    Channel entries are resolved via ``virtual_gate_sets[gate_set_id].channels[key]``
-    so ``#/`` references are followed while the gate set is already under this root.
+    Uses :func:`_dac_mapping_from_wiring`. No-op when wiring defines no QDAC DC outputs.
     """
+    by_gate = _dac_mapping_from_wiring(machine)
+    if not by_gate:
+        return
     for vgs_key in machine.virtual_gate_sets.keys():
         vgs = machine.virtual_gate_sets[vgs_key]
         for channel_name in list(vgs.channels.keys()):
             gate = vgs.channels[channel_name]
             if not isinstance(gate, VoltageGate):
                 continue
-            if gate.name not in dac_mapping:
+            entry = None
+            for cand in (
+                channel_name,
+                getattr(gate, "id", None),
+                getattr(gate, "name", None),
+            ):
+                if cand and cand in by_gate:
+                    entry = by_gate[cand]
+                    break
+            if entry is None:
                 continue
-            entry = dac_mapping[gate.name]
             ch_nb = entry.get("ch")
             if ch_nb is None:
                 continue
+            entry_dac = entry.get("dac_name", dac_name)
+            entry_qti = entry.get("qdac_trigger_in", qdac_trigger_in)
             _wire_voltage_gate_qdac(
                 gate,
                 qdac_output_port=ch_nb,
-                dac_name=dac_name,
+                dac_name=entry_dac,
                 with_trigger_channel=bool(entry.get("trigger", False)),
                 digital_output_key=digital_output_key,
-                qdac_trigger_in=qdac_trigger_in,
+                qdac_trigger_in=entry_qti,
                 trigger_pulse_length_ns=trigger_pulse_length_ns,
             )

--- a/quam_builder/builder/quantum_dots/build_quam.py
+++ b/quam_builder/builder/quantum_dots/build_quam.py
@@ -632,7 +632,7 @@ def _wire_voltage_gate_qdac(
         with_trigger_channel: If True, move ``digital_output_key`` into a wrapper
             ``Channel`` referenced by ``QdacSpec.opx_trigger_out``.
         digital_output_key: Name of the digital output on the gate (default wiring
-            uses ``qdac_trig_0``).
+            uses ``qdac_trig``).
         qdac_trigger_in: Optional QDAC external trigger port.
         trigger_pulse_length_ns: Length of the default ``trigger`` pulse on the
             wrapper channel when ``with_trigger_channel`` is True.
@@ -660,7 +660,7 @@ def _wire_voltage_gate_qdac(
 def add_dacs(
     machine: BaseQuamQD,
     *,
-    digital_output_key: str = "qdac_trig_0",
+    digital_output_key: str = "qdac_trig",
     dac_name: str = "qdac",
     qdac_trigger_in: Optional[int] = None,
     trigger_pulse_length_ns: int = 100,

--- a/quam_builder/builder/quantum_dots/build_utils.py
+++ b/quam_builder/builder/quantum_dots/build_utils.py
@@ -354,6 +354,9 @@ def _make_voltage_gate_with_qdac(
     )
     if qdac_channel is not None:
         gate.qdac_channel = qdac_channel
+    qdac_trigger_in = ports.get("qdac_trigger_in")
+    if qdac_trigger_in is not None:
+        gate.qdac_trigger_in = qdac_trigger_in
     return gate
 
 

--- a/quam_builder/builder/quantum_dots/build_utils.py
+++ b/quam_builder/builder/quantum_dots/build_utils.py
@@ -318,15 +318,14 @@ def _parse_qubit_pair_ids(qubit_pair_id: str) -> Tuple[str, str]:
 
 
 def _extract_qdac_channel(wiring_dict: Dict[str, Any]) -> int | None:
-    """Extract QDAC channel number from wiring configuration.
+    """Extract QDAC DC output port index from wiring (legacy int or structured block).
 
-    Args:
-        wiring_dict: Wiring dictionary that may contain 'qdac_channel' key.
-
-    Returns:
-        QDAC channel number if present, None otherwise.
+    Prefer the structured ``qdac_output`` dict from :mod:`quam_builder.builder.qop_connectivity.qdac_wiring`;
+    fall back to legacy ``qdac_channel`` integer.
     """
-    return wiring_dict.get("qdac_channel")
+    from quam_builder.builder.qop_connectivity.qdac_wiring import extract_qdac_output_port
+
+    return extract_qdac_output_port(wiring_dict)
 
 
 def _make_voltage_gate_with_qdac(
@@ -354,9 +353,21 @@ def _make_voltage_gate_with_qdac(
     )
     if qdac_channel is not None:
         gate.qdac_channel = qdac_channel
-    qdac_trigger_in = ports.get("qdac_trigger_in")
+    from quam_builder.builder.qop_connectivity.qdac_wiring import (
+        extract_qdac_trigger_port,
+        extract_qdac_trigger_unit_index,
+        extract_qdac_unit_index,
+    )
+
+    qdac_unit = extract_qdac_unit_index(ports)
+    if qdac_unit is not None:
+        gate.qdac_unit_index = qdac_unit
+    qdac_trigger_in = extract_qdac_trigger_port(ports)
     if qdac_trigger_in is not None:
         gate.qdac_trigger_in = qdac_trigger_in
+    qdac_trig_unit = extract_qdac_trigger_unit_index(ports)
+    if qdac_trig_unit is not None:
+        gate.qdac_trigger_unit_index = qdac_trig_unit
     return gate
 
 

--- a/quam_builder/builder/quantum_dots/build_utils.py
+++ b/quam_builder/builder/quantum_dots/build_utils.py
@@ -317,6 +317,27 @@ def _parse_qubit_pair_ids(qubit_pair_id: str) -> Tuple[str, str]:
     return control, target
 
 
+_OPX_ANALOG_WIRING_KEYS = frozenset({"opx_output", "opx_output_I", "opx_output_Q"})
+
+
+def _wiring_has_opx_analog_output(ports: Any) -> bool:
+    """True if the line wiring includes an OPX/LF analog port reference (not QDAC-only)."""
+    if not ports or not hasattr(ports, "keys"):
+        return False
+    for key in ports.keys():
+        if key not in _OPX_ANALOG_WIRING_KEYS:
+            continue
+        if hasattr(ports, "get_unreferenced_value"):
+            raw = ports.get_unreferenced_value(key)
+        elif hasattr(ports, "get"):
+            raw = ports.get(key)
+        else:
+            raw = ports[key]
+        if raw is not None and raw != "":
+            return True
+    return False
+
+
 def _extract_qdac_channel(wiring_dict: Dict[str, Any]) -> int | None:
     """Extract QDAC DC output port index from wiring (legacy int or structured block).
 
@@ -329,25 +350,29 @@ def _extract_qdac_channel(wiring_dict: Dict[str, Any]) -> int | None:
 
 
 def _make_voltage_gate_with_qdac(
-    gate_id: str, wiring_path: str, ports: Dict[str, str], qdac_channel: int | None = None
+    gate_id: str, wiring_path: str, ports: Mapping[str, Any], qdac_channel: int | None = None
 ) -> VoltageGate:
     """Create a voltage gate component with sticky channel and optional QDAC mapping.
 
     Args:
         gate_id: Identifier for the gate.
         wiring_path: JSON path to wiring configuration.
-        ports (Dict[str, str]): A dictionary mapping port names to their respective configurations.
+        ports: Port mapping for this line (OPX refs, ``qdac_output``, digitals, etc.).
         qdac_channel: Optional QDAC channel number for external voltage control.
 
     Returns:
         Configured VoltageGate instance with QDAC channel if provided.
+
+    When wiring is **QDAC-only** (no OPX/LF analog port keys), :attr:`VoltageGate.opx_output`
+    is set to ``None`` so QUAM does not resolve a missing ``#/wiring/.../opx_output`` path.
     """
 
     digital_outputs = get_digital_outputs(wiring_path, ports, "qdac_trig")
+    opx_out = f"{wiring_path}/opx_output" if _wiring_has_opx_analog_output(ports) else None
 
     gate = VoltageGate(
         id=gate_id,
-        opx_output=f"{wiring_path}/opx_output",
+        opx_output=opx_out,
         sticky=_make_sticky_channel(),
         digital_outputs=digital_outputs,
     )

--- a/quam_builder/builder/quantum_dots/build_utils.py
+++ b/quam_builder/builder/quantum_dots/build_utils.py
@@ -365,15 +365,17 @@ def _make_voltage_gate_with_qdac(
 
     When wiring is **QDAC-only** (no OPX/LF analog port keys), :attr:`VoltageGate.opx_output`
     is set to ``None`` so QUAM does not resolve a missing ``#/wiring/.../opx_output`` path.
+    Sticky is omitted so :meth:`~quam.core.quam_classes.QuamRoot.generate_config` does not touch OPX.
     """
 
     digital_outputs = get_digital_outputs(wiring_path, ports, "qdac_trig")
     opx_out = f"{wiring_path}/opx_output" if _wiring_has_opx_analog_output(ports) else None
+    sticky = _make_sticky_channel() if opx_out is not None else None
 
     gate = VoltageGate(
         id=gate_id,
         opx_output=opx_out,
-        sticky=_make_sticky_channel(),
+        sticky=sticky,
         digital_outputs=digital_outputs,
     )
     if qdac_channel is not None:

--- a/quam_builder/builder/quantum_dots/build_utils.py
+++ b/quam_builder/builder/quantum_dots/build_utils.py
@@ -356,6 +356,9 @@ def _make_voltage_gate_with_qdac(
     )
     if qdac_channel is not None:
         gate.qdac_channel = qdac_channel
+    qdac_trigger_in = ports.get("qdac_trigger_in")
+    if qdac_trigger_in is not None:
+        gate.qdac_trigger_in = qdac_trigger_in
     return gate
 
 

--- a/quam_builder/builder/quantum_dots/build_utils.py
+++ b/quam_builder/builder/quantum_dots/build_utils.py
@@ -320,15 +320,14 @@ def _parse_qubit_pair_ids(qubit_pair_id: str) -> Tuple[str, str]:
 
 
 def _extract_qdac_channel(wiring_dict: Dict[str, Any]) -> int | None:
-    """Extract QDAC channel number from wiring configuration.
+    """Extract QDAC DC output port index from wiring (legacy int or structured block).
 
-    Args:
-        wiring_dict: Wiring dictionary that may contain 'qdac_channel' key.
-
-    Returns:
-        QDAC channel number if present, None otherwise.
+    Prefer the structured ``qdac_output`` dict from :mod:`quam_builder.builder.qop_connectivity.qdac_wiring`;
+    fall back to legacy ``qdac_channel`` integer.
     """
-    return wiring_dict.get("qdac_channel")
+    from quam_builder.builder.qop_connectivity.qdac_wiring import extract_qdac_output_port
+
+    return extract_qdac_output_port(wiring_dict)
 
 
 def _make_voltage_gate_with_qdac(
@@ -356,9 +355,21 @@ def _make_voltage_gate_with_qdac(
     )
     if qdac_channel is not None:
         gate.qdac_channel = qdac_channel
-    qdac_trigger_in = ports.get("qdac_trigger_in")
+    from quam_builder.builder.qop_connectivity.qdac_wiring import (
+        extract_qdac_trigger_port,
+        extract_qdac_trigger_unit_index,
+        extract_qdac_unit_index,
+    )
+
+    qdac_unit = extract_qdac_unit_index(ports)
+    if qdac_unit is not None:
+        gate.qdac_unit_index = qdac_unit
+    qdac_trigger_in = extract_qdac_trigger_port(ports)
     if qdac_trigger_in is not None:
         gate.qdac_trigger_in = qdac_trigger_in
+    qdac_trig_unit = extract_qdac_trigger_unit_index(ports)
+    if qdac_trig_unit is not None:
+        gate.qdac_trigger_unit_index = qdac_trig_unit
     return gate
 
 

--- a/quam_builder/builder/quantum_dots/build_utils.py
+++ b/quam_builder/builder/quantum_dots/build_utils.py
@@ -367,15 +367,17 @@ def _make_voltage_gate_with_qdac(
 
     When wiring is **QDAC-only** (no OPX/LF analog port keys), :attr:`VoltageGate.opx_output`
     is set to ``None`` so QUAM does not resolve a missing ``#/wiring/.../opx_output`` path.
+    Sticky is omitted so :meth:`~quam.core.quam_classes.QuamRoot.generate_config` does not touch OPX.
     """
 
     digital_outputs = get_digital_outputs(wiring_path, ports, "qdac_trig")
     opx_out = f"{wiring_path}/opx_output" if _wiring_has_opx_analog_output(ports) else None
+    sticky = _make_sticky_channel() if opx_out is not None else None
 
     gate = VoltageGate(
         id=gate_id,
         opx_output=opx_out,
-        sticky=_make_sticky_channel(),
+        sticky=sticky,
         digital_outputs=digital_outputs,
     )
     if qdac_channel is not None:

--- a/quam_builder/builder/quantum_dots/build_utils.py
+++ b/quam_builder/builder/quantum_dots/build_utils.py
@@ -319,6 +319,27 @@ def _parse_qubit_pair_ids(qubit_pair_id: str) -> Tuple[str, str]:
     return control, target
 
 
+_OPX_ANALOG_WIRING_KEYS = frozenset({"opx_output", "opx_output_I", "opx_output_Q"})
+
+
+def _wiring_has_opx_analog_output(ports: Any) -> bool:
+    """True if the line wiring includes an OPX/LF analog port reference (not QDAC-only)."""
+    if not ports or not hasattr(ports, "keys"):
+        return False
+    for key in ports.keys():
+        if key not in _OPX_ANALOG_WIRING_KEYS:
+            continue
+        if hasattr(ports, "get_unreferenced_value"):
+            raw = ports.get_unreferenced_value(key)
+        elif hasattr(ports, "get"):
+            raw = ports.get(key)
+        else:
+            raw = ports[key]
+        if raw is not None and raw != "":
+            return True
+    return False
+
+
 def _extract_qdac_channel(wiring_dict: Dict[str, Any]) -> int | None:
     """Extract QDAC DC output port index from wiring (legacy int or structured block).
 
@@ -331,25 +352,29 @@ def _extract_qdac_channel(wiring_dict: Dict[str, Any]) -> int | None:
 
 
 def _make_voltage_gate_with_qdac(
-    gate_id: str, wiring_path: str, ports: Dict[str, str], qdac_channel: int | None = None
+    gate_id: str, wiring_path: str, ports: Mapping[str, Any], qdac_channel: int | None = None
 ) -> VoltageGate:
     """Create a voltage gate component with sticky channel and optional QDAC mapping.
 
     Args:
         gate_id: Identifier for the gate.
         wiring_path: JSON path to wiring configuration.
-        ports (Dict[str, str]): A dictionary mapping port names to their respective configurations.
+        ports: Port mapping for this line (OPX refs, ``qdac_output``, digitals, etc.).
         qdac_channel: Optional QDAC channel number for external voltage control.
 
     Returns:
         Configured VoltageGate instance with QDAC channel if provided.
+
+    When wiring is **QDAC-only** (no OPX/LF analog port keys), :attr:`VoltageGate.opx_output`
+    is set to ``None`` so QUAM does not resolve a missing ``#/wiring/.../opx_output`` path.
     """
 
     digital_outputs = get_digital_outputs(wiring_path, ports, "qdac_trig")
+    opx_out = f"{wiring_path}/opx_output" if _wiring_has_opx_analog_output(ports) else None
 
     gate = VoltageGate(
         id=gate_id,
-        opx_output=f"{wiring_path}/opx_output",
+        opx_output=opx_out,
         sticky=_make_sticky_channel(),
         digital_outputs=digital_outputs,
     )

--- a/quam_builder/tools/voltage_sequence/voltage_sequence.py
+++ b/quam_builder/tools/voltage_sequence/voltage_sequence.py
@@ -21,6 +21,7 @@ from qm.qua.type_hints import (
 )
 
 from quam.components.channels import SingleChannel
+from quam.components.pulses import SquarePulse
 
 from quam_builder.architecture.quantum_dots.components.gate_set import (
     GateSet,
@@ -122,6 +123,7 @@ class VoltageSequence:
 
         """
         self.gate_set: GateSet = gate_set
+        self._update_baseband_pulse_amplitude()
         self.state_trackers: Dict[str, SequenceStateTracker] = {
             ch_name: SequenceStateTracker(
                 ch_name,
@@ -139,6 +141,23 @@ class VoltageSequence:
 
         self._batched_voltages = None
         self._prog_id = None
+
+    def _update_baseband_pulse_amplitude(self):
+        for ch in self.gate_set.channels.values():
+            if ch.opx_output is not None:
+                if DEFAULT_PULSE_NAME not in ch.operations:
+                    ch.operations[DEFAULT_PULSE_NAME] = SquarePulse(
+                        id=DEFAULT_PULSE_NAME,
+                        length=MIN_PULSE_DURATION_NS,
+                        amplitude=0.25,
+                    )
+                output_mode = getattr(ch.opx_output, "output_mode", None)
+                if output_mode is None:
+                    ch.operations[DEFAULT_PULSE_NAME].amplitude = 0.25
+                elif output_mode == "direct":
+                    ch.operations[DEFAULT_PULSE_NAME].amplitude = 0.25
+                elif output_mode == "amplified":
+                    ch.operations[DEFAULT_PULSE_NAME].amplitude = 1.25
 
     def _initialise_attenuation_qua_vars(self) -> None:
         """Lazy initiation of QUA variables that runs only at the start of the QUA program."""

--- a/quam_builder/tools/voltage_sequence/voltage_sequence.py
+++ b/quam_builder/tools/voltage_sequence/voltage_sequence.py
@@ -21,6 +21,7 @@ from qm.qua.type_hints import (
 )
 
 from quam.components.channels import SingleChannel
+from quam.components.pulses import SquarePulse
 
 from quam_builder.architecture.quantum_dots.components.gate_set import (
     GateSet,
@@ -128,6 +129,7 @@ class VoltageSequence:
 
         """
         self.gate_set: GateSet = gate_set
+        self._update_baseband_pulse_amplitude()
         self.state_trackers: Dict[str, SequenceStateTracker] = {
             ch_name: SequenceStateTracker(
                 ch_name,
@@ -190,6 +192,23 @@ class VoltageSequence:
         if update_prog_id:
             self._prog_id = current_program_scope
         return is_new
+
+    def _update_baseband_pulse_amplitude(self):
+        for ch in self.gate_set.channels.values():
+            if ch.opx_output is not None:
+                if DEFAULT_PULSE_NAME not in ch.operations:
+                    ch.operations[DEFAULT_PULSE_NAME] = SquarePulse(
+                        id=DEFAULT_PULSE_NAME,
+                        length=MIN_PULSE_DURATION_NS,
+                        amplitude=0.25,
+                    )
+                output_mode = getattr(ch.opx_output, "output_mode", None)
+                if output_mode is None:
+                    ch.operations[DEFAULT_PULSE_NAME].amplitude = 0.25
+                elif output_mode == "direct":
+                    ch.operations[DEFAULT_PULSE_NAME].amplitude = 0.25
+                elif output_mode == "amplified":
+                    ch.operations[DEFAULT_PULSE_NAME].amplitude = 1.25
 
     def _initialise_attenuation_qua_vars(self) -> None:
         """Lazy initiation of QUA variables that runs only at the start of the QUA program."""

--- a/tests/builder/quantum_dots/test_wirer_builder_integration.py
+++ b/tests/builder/quantum_dots/test_wirer_builder_integration.py
@@ -154,7 +154,9 @@ class TestWirerBuilderIntegration:
 
         gate_wiring = machine.wiring["globals"]["vg1"][WiringLineType.GLOBAL_GATE.value]
         assert "opx_output" in gate_wiring
-        assert gate_wiring["qdac_channel"] == 1
+        qo = gate_wiring["qdac_output"]
+        assert qo["unit_index"] == 1 and qo["port"] == 1
+        assert qo["ref"] == "#/qdac/analog_outputs/qdac1/1"
 
     def test_example_two_stage_workflow(self, temp_dir):
         """Exercise the two-stage flow used in wiring_example."""

--- a/tests/builder/quantum_dots/test_wirer_builder_integration.py
+++ b/tests/builder/quantum_dots/test_wirer_builder_integration.py
@@ -236,6 +236,64 @@ class TestWirerBuilderIntegration:
         assert gate.dac_spec.qdac_output_port == 1
         assert gate.dac_spec.dac_name == "qdac1"
 
+    def test_make_voltage_gate_qdac_only_skips_opx_output_ref(self):
+        """QDAC-only wiring must not set a dangling ``#/wiring/.../opx_output`` reference."""
+        from quam_builder.builder.quantum_dots.build_utils import _make_voltage_gate_with_qdac
+
+        ports = {
+            "qdac_output": {"unit_index": 1, "port": 10, "ref": "qdac/analog_outputs/qdac1/10"},
+        }
+        gate = _make_voltage_gate_with_qdac(
+            "source", "#/wiring/globals/source/g", ports, qdac_channel=10
+        )
+        assert gate.opx_output is None
+        assert gate.qdac_channel == 10
+
+    def test_make_voltage_gate_lf_plus_qdac_keeps_opx_output_ref(self):
+        from quam_builder.builder.quantum_dots.build_utils import _make_voltage_gate_with_qdac
+
+        ports = {
+            "opx_output": "#/ports/analog_outputs/con1/1/1/1",
+            "qdac_output": {"unit_index": 1, "port": 3, "ref": "qdac/analog_outputs/qdac1/3"},
+        }
+        gate = _make_voltage_gate_with_qdac(
+            "vg1", "#/wiring/globals/vg1/g", ports, qdac_channel=3
+        )
+        assert gate.opx_output == "#/wiring/globals/vg1/g/opx_output"
+
+    def test_global_voltage_gate_qdac_only_stage1(self, temp_dir):
+        """Global gate with only QDAC2 channels: Stage 1 builds a gate without OPX analog ref."""
+        instruments = Instruments()
+        instruments.add_qdac2(indices=1)
+        connectivity = Connectivity()
+        connectivity.add_voltage_gate_lines(
+            "source",
+            name="",
+            triggered=False,
+            constraints=qdac2_spec(index=1, out_port=10),
+        )
+        allocate_wiring(connectivity, instruments)
+
+        machine = BaseQuamQD()
+        machine = build_quam_wiring(
+            connectivity,
+            host_ip="127.0.0.1",
+            cluster_name="test_cluster",
+            quam_instance=machine,
+            path=temp_dir,
+        )
+        build_base_quam(
+            machine,
+            calibration_db_path=temp_dir,
+            connect_qdac=False,
+            save=False,
+        )
+
+        vgs = machine.virtual_gate_sets["main_qpu"]
+        gate = vgs.channels["source"]
+        assert gate.opx_output is None
+        assert gate.qdac_channel == 10
+
     def test_example_two_stage_workflow(self, temp_dir):
         """Exercise the two-stage flow used in wiring_example."""
         qubit_pair_sensor_map = {"q1_q2": ["sensor_1"], "q2_q3": ["sensor_2"]}

--- a/tests/builder/quantum_dots/test_wirer_builder_integration.py
+++ b/tests/builder/quantum_dots/test_wirer_builder_integration.py
@@ -158,6 +158,41 @@ class TestWirerBuilderIntegration:
         assert qo["unit_index"] == 1 and qo["port"] == 1
         assert qo["ref"] == "#/qdac/analog_outputs/qdac1/1"
 
+    def test_qdac_spec_from_wiring(self, temp_dir):
+        """Stage 1 attaches QdacSpec from ``machine.wiring``."""
+        instruments = Instruments()
+        instruments.add_lf_fem(controller=1, slots=[1])
+        instruments.add_qdac2(indices=1)
+        connectivity = Connectivity()
+        connectivity.add_voltage_gate_lines(
+            [1],
+            triggered=False,
+            name="vg",
+            constraints=lf_fem_spec(con=1, out_slot=1) & qdac2_spec(index=1),
+        )
+        allocate_wiring(connectivity, instruments)
+
+        machine = BaseQuamQD()
+        machine = build_quam_wiring(
+            connectivity,
+            host_ip="127.0.0.1",
+            cluster_name="test_cluster",
+            quam_instance=machine,
+            path=temp_dir,
+        )
+        build_base_quam(
+            machine,
+            calibration_db_path=temp_dir,
+            connect_qdac=False,
+            save=False,
+        )
+
+        vgs = machine.virtual_gate_sets["main_qpu"]
+        gate = vgs.channels["vg1"]
+        assert gate.dac_spec is not None
+        assert gate.dac_spec.qdac_output_port == 1
+        assert gate.dac_spec.dac_name == "qdac1"
+
     def test_example_two_stage_workflow(self, temp_dir):
         """Exercise the two-stage flow used in wiring_example."""
         qubit_pair_sensor_map = {"q1_q2": ["sensor_1"], "q2_q3": ["sensor_2"]}

--- a/tests/builder/quantum_dots/test_wirer_builder_integration.py
+++ b/tests/builder/quantum_dots/test_wirer_builder_integration.py
@@ -248,6 +248,7 @@ class TestWirerBuilderIntegration:
         )
         assert gate.opx_output is None
         assert gate.qdac_channel == 10
+        assert gate.sticky is None
 
     def test_make_voltage_gate_lf_plus_qdac_keeps_opx_output_ref(self):
         from quam_builder.builder.quantum_dots.build_utils import _make_voltage_gate_with_qdac
@@ -293,6 +294,9 @@ class TestWirerBuilderIntegration:
         gate = vgs.channels["source"]
         assert gate.opx_output is None
         assert gate.qdac_channel == 10
+        assert gate.sticky is None
+        qua_cfg = machine.generate_config()
+        assert "source" not in qua_cfg.get("elements", {})
 
     def test_example_two_stage_workflow(self, temp_dir):
         """Exercise the two-stage flow used in wiring_example."""

--- a/tests/builder/quantum_dots/test_wirer_builder_integration.py
+++ b/tests/builder/quantum_dots/test_wirer_builder_integration.py
@@ -8,7 +8,13 @@ from pathlib import Path
 
 import pytest
 
-from qualang_tools.wirer import Instruments, Connectivity, allocate_wiring
+from qualang_tools.wirer import (
+    Instruments,
+    Connectivity,
+    allocate_wiring,
+    lf_fem_spec,
+    qdac2_spec,
+)
 from qualang_tools.wirer.connectivity.wiring_spec import WiringLineType
 from quam_builder.builder.qop_connectivity import build_quam_wiring
 from quam_builder.builder.quantum_dots import (
@@ -122,6 +128,33 @@ class TestWirerBuilderIntegration:
         # Verify QPU elements were created
         assert len(machine.sensor_dots) > 0
         assert len(machine.quantum_dots) > 0
+
+    def test_build_quam_wiring_lf_fem_and_qdac2_dual_voltage_gate(self, temp_dir):
+        """Wiring dict includes LF analog ref and QDAC2 channel index from wirer allocation."""
+        instruments = Instruments()
+        instruments.add_lf_fem(controller=1, slots=[1])
+        instruments.add_qdac2(indices=1)
+        connectivity = Connectivity()
+        connectivity.add_voltage_gate_lines(
+            [1],
+            triggered=False,
+            name="vg",
+            constraints=lf_fem_spec(con=1, out_slot=1) & qdac2_spec(index=1),
+        )
+        allocate_wiring(connectivity, instruments)
+
+        machine = BaseQuamQD()
+        machine = build_quam_wiring(
+            connectivity,
+            host_ip="127.0.0.1",
+            cluster_name="test_cluster",
+            quam_instance=machine,
+            path=temp_dir,
+        )
+
+        gate_wiring = machine.wiring["globals"]["vg1"][WiringLineType.GLOBAL_GATE.value]
+        assert "opx_output" in gate_wiring
+        assert gate_wiring["qdac_channel"] == 1
 
     def test_example_two_stage_workflow(self, temp_dir):
         """Exercise the two-stage flow used in wiring_example."""

--- a/tests/builder/quantum_dots/test_wirer_builder_integration.py
+++ b/tests/builder/quantum_dots/test_wirer_builder_integration.py
@@ -156,7 +156,7 @@ class TestWirerBuilderIntegration:
         assert "opx_output" in gate_wiring
         qo = gate_wiring["qdac_output"]
         assert qo["unit_index"] == 1 and qo["port"] == 1
-        assert qo["ref"] == "#/qdac/analog_outputs/qdac1/1"
+        assert qo["ref"] == "qdac/analog_outputs/qdac1/1"
 
     def test_qdac_spec_from_wiring(self, temp_dir):
         """Stage 1 attaches QdacSpec from ``machine.wiring``."""

--- a/tests/builder/quantum_dots/test_wirer_builder_integration.py
+++ b/tests/builder/quantum_dots/test_wirer_builder_integration.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=too-few-public-methods
 
+import json
 import shutil
 import tempfile
 from pathlib import Path
@@ -157,6 +158,48 @@ class TestWirerBuilderIntegration:
         qo = gate_wiring["qdac_output"]
         assert qo["unit_index"] == 1 and qo["port"] == 1
         assert qo["ref"] == "qdac/analog_outputs/qdac1/1"
+
+    def test_dac_config_round_trip_in_wiring_json(self, temp_dir):
+        """DAC driver map is stored under ``dac_config`` in ``wiring.json``."""
+        dac_cfg = {
+            "qdac1": {
+                "driver_module": "qcodes_contrib_drivers.drivers.QDevil.QDAC2",
+                "driver_class": "QDac2",
+                "connection": {"visalib": "@py", "address": "TCPIP::127.0.0.1::5025::SOCKET"},
+                "channel_method": "channel",
+                "accessor": "dc_constant_V",
+                "is_qdac": True,
+            },
+            "qdac2": {
+                "driver_module": "qcodes_contrib_drivers.drivers.QDevil.QDAC2",
+                "driver_class": "QDac2",
+                "connection": {"visalib": "@py", "address": "TCPIP::127.0.0.2::5025::SOCKET"},
+                "channel_method": "channel",
+                "accessor": "dc_constant_V",
+                "is_qdac": True,
+            },
+        }
+        instruments = Instruments()
+        instruments.add_lf_fem(controller=1, slots=[1])
+        connectivity = Connectivity()
+        connectivity.add_quantum_dots(quantum_dots=[1], add_drive_lines=False)
+        allocate_wiring(connectivity, instruments)
+
+        machine = BaseQuamQD()
+        build_quam_wiring(
+            connectivity,
+            host_ip="127.0.0.1",
+            cluster_name="test_cluster",
+            quam_instance=machine,
+            path=temp_dir,
+            dac_config=dac_cfg,
+        )
+
+        wiring_files = list(Path(temp_dir).rglob("wiring.json"))
+        assert wiring_files, "expected wiring.json under save path"
+        on_disk = json.loads(wiring_files[0].read_text(encoding="utf-8"))
+        assert on_disk.get("dac_config") == dac_cfg
+        assert on_disk.get("network", {}).get("host") == "127.0.0.1"
 
     def test_qdac_spec_from_wiring(self, temp_dir):
         """Stage 1 attaches QdacSpec from ``machine.wiring``."""


### PR DESCRIPTION
# Pull Request

## Description

This branch completes end-to-end **QDAC2 wiring and configuration** for quantum-dot QUAM builds: structured QDAC entries in `machine.wiring`, automatic **`QdacSpec`** attachment from that wiring (no manual `dac_mapping`), **logical (non-resolvable) QDAC reference strings** to avoid QUAM `#/` pointer warnings, and **DAC driver configuration** stored in **`wiring.json`** under `dac_config` (aligned with how `network` is stored), with optional injection via **`build_quam_wiring(..., dac_config=...)`**.

High-level changes:

- **Wiring shape:** `qdac_output` / `qdac_trigger` blocks with `unit_index`, `port`, and a stable **`ref`** string (logical path, **not** a QUAM JSON pointer—no `#/` prefix) plus legacy fallbacks where applicable.
- **Builder:** `build_base_quam` / `build_quam` apply QDAC specs using **`_dac_mapping_from_wiring`**, mirroring Stage 1 gate IDs and barrier indexing; **`dac_mapping` was removed** from the public API.
- **`add_dacs`:** Takes only the machine (and optional kwargs); always derives the gate map from wiring.
- **Persistence:** `BaseQuamQD.dac_config` is serialized with **`wiring`** and **`network`** in **`wiring.json`**; **`set_dac_config`** updates that field. Separate **`dac/*.jsonc`** write/read paths are **removed** (no legacy migration on load).
- **Ports:** Ensures a ports container exists for QDAC-only connectivity so machine state remains valid.
- Allow QDAC only components that won't appear in the opx configuration (machine.generate_config()).
- **Tests:** Integration coverage for structured QDAC wiring, `QdacSpec` from wiring, `dac_config` round-trip in `wiring.json`, etc.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [x] ✅ Test addition/update
- [ ] 🎨 Code style/formatting update

## Related Issues

<!-- Link related issues using keywords: Closes #123, Fixes #456, Relates to #789 -->
Related to [PR-341](https://github.com/qua-platform/py-qua-tools/pull/341) on qualang-tools

## Checklist

### Code Quality

- [ ] My code follows the project's style guidelines
- [ ] I have run `pre-commit` hooks and all checks pass (`pre-commit run --all-files`)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings

### Testing

- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass locally (`pytest`)
- [ ] I have tested my changes with the example scripts (if applicable)

### Documentation

- [ ] I have updated the documentation (if needed)
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md (if applicable)
- [ ] I have checked my code and corrected any misspellings

## Breaking Changes

**Does this PR introduce breaking changes?** Yes

- **`dac_mapping` removed** from `build_base_quam` and `build_quam`. QDAC output/trigger metadata must come from **`machine.wiring`** (`qdac_output` / legacy `qdac_channel`, etc.). Overrides previously done only via `dac_mapping` should be expressed in wiring or by post-build APIs (e.g. `BaseQuamQD.wire_voltage_gate_qdac` / `apply_qdac_channel_mapping`) if still needed.
- **`add_dacs(machine, ...)`** no longer accepts a mapping argument; wiring is the single source of truth for which gates get `QdacSpec`.
- **DAC configuration persistence:** `dac_config` now lives in **`wiring.json`**. The old **`dac/*.jsonc`** layout is **no longer written or read** on save/load. Existing repos that relied on that folder must **migrate** entries into `wiring.json` → `dac_config` (or set `dac_config` before save).
- **`ref` strings** under `qdac_output` / `qdac_trigger` are **no longer** `#/qdac/...` QUAM pointers; they are **logical paths** (e.g. `qdac/analog_outputs/qdac1/1`). Anything that assumed a `#/` prefix must be updated.

**Migration guide (summary):**

1. Regenerate or edit **`wiring.json`**: add **`dac_config`** with the same structure previously passed to **`set_dac_config`** (per-DAC keys like `qdac1`, `qdac2`, …).
2. Remove reliance on **`dac_mapping`** in `build_base_quam` / `build_quam`; ensure wirer/builder emits **`qdac_output`** (and triggers if used) on the relevant lines.
3. Optionally pass **`dac_config`** into **`build_quam_wiring(...)`** when creating wiring so the first save already contains network + wiring + DAC config together.
4. Drop dependence on **`dac/*.jsonc`**; merge those files into **`dac_config`** in **`wiring.json`** if you still have old state directories.

## Testing Details

- **Environment:** Python **3.11+** recommended (project/tests may depend on `StrEnum` and other 3.11 APIs); confirm in CI.
- **Automated:** Run **`pytest`** for `quam-builder` (e.g. `tests/builder/quantum_dots/test_wirer_builder_integration.py` and related builder tests).
- **Manual / scripts:** Run a flow that calls **`build_quam_wiring`** (with and without **`dac_config`**), then **`build_base_quam`** / **`build_quam`**, save, reload, and confirm:
  - No spurious **`Could not get reference "#/qdac/..."`** warnings from wiring traversal.
  - **`wiring.json`** contains **`wiring`**, **`network`**, and **`dac_config`** as expected.
  - **`connect_to_external_source`** works when **`dac_config`** is populated and `QdacSpec.dac_name` keys match **`dac_config`** entries.

## Screenshots/Examples

**Example `dac_config` (in `wiring.json`):**

```json
{
  "wiring": { },
  "network": { "host": "...", "port": null, "cluster_name": "..." },
  "dac_config": {
    "qdac1": {
      "driver_module": "qcodes_contrib_drivers.drivers.QDevil.QDAC2",
      "driver_class": "QDac2",
      "connection": { "visalib": "@py", "address": "TCPIP::<ip>::5025::SOCKET" },
      "channel_method": "channel",
      "accessor": "dc_constant_V",
      "is_qdac": true
    }
  }
}