### PR TITLE
Added calculation of new max voltage instead of throwing an error.

### DIFF
--- a/quam_builder/tools/voltage_sequence/voltage_sequence.py
+++ b/quam_builder/tools/voltage_sequence/voltage_sequence.py
@@ -133,6 +133,20 @@ class VoltageSequence:
         self._temp_qua_vars: Dict[str, QuaVariable] = {}  # For ramp_rate etc.
         self._track_integrated_voltage: bool = track_integrated_voltage
         self._keep_levels: bool = keep_levels
+        self._channel_max_voltage: Dict[str, float] = {}
+
+        for ch_name, channel_obj in self.gate_set.channels.items():
+            if self.gate_set.adjust_for_attenuation and hasattr(channel_obj, "attenuation"):
+                opx_voltage_limit = (
+                    2.5
+                    if hasattr(channel_obj.opx_output, "output_mode")
+                    and channel_obj.opx_output.output_mode == "amplified"
+                    else 0.5
+                )
+                attenuation_scale = 10 ** (channel_obj.attenuation / 20)
+                self._channel_max_voltage[ch_name] = opx_voltage_limit / attenuation_scale
+            else:
+                self._channel_max_voltage[ch_name] = opx_voltage_limit
 
         if self._keep_levels:
             self._keep_levels_tracker = KeepLevels(self.gate_set)
@@ -715,24 +729,13 @@ class VoltageSequence:
         for ch_name, channel_obj in self.gate_set.channels.items():
             DEFAULT_WF_AMPLITUDE = channel_obj.operations[DEFAULT_PULSE_NAME].amplitude
             DEFAULT_AMPLITUDE_BITSHIFT = int(np.log2(1 / DEFAULT_WF_AMPLITUDE))
-            opx_voltage_limit = (
-                2.5
-                if hasattr(channel_obj.opx_output, "output_mode")
-                and channel_obj.opx_output.output_mode == "amplified"
-                else 0.5
-            )
-
-            # Determine channel-specific max_voltage to use, based on attenuation (but without mutating the loop max_voltage)
-            channel_max_voltage = max_voltage
-            if self.gate_set.adjust_for_attenuation and hasattr(channel_obj, "attenuation"):
-                attenuation_scale = 10 ** (channel_obj.attenuation / 20)
-                if channel_max_voltage * attenuation_scale > opx_voltage_limit:
-                    new_max_voltage = opx_voltage_limit / attenuation_scale
-                    print(
-                        f"Channel '{ch_name}': attenuation-corrected max_voltage ({channel_max_voltage * attenuation_scale:.2f}) exceeds OPX output limit of {opx_voltage_limit}. "
-                        f"Using reduced max_voltage of {new_max_voltage:.4f} instead of supplied {channel_max_voltage:.4f}."
-                    )
-                    channel_max_voltage = new_max_voltage
+            channel_limit = self._channel_max_voltage[ch_name]
+            channel_max_voltage = min(max_voltage, channel_limit)
+            if max_voltage > channel_limit:
+                print(
+                    f"Channel '{ch_name}': supplied max_voltage ({max_voltage:.4f}) exceeds channel max_voltage "
+                    f"({channel_limit:.4f}). Using reduced max_voltage of {channel_max_voltage:.4f}."
+                )
 
             tracker = self.state_trackers[ch_name]
             current_v = tracker.current_level

--- a/quam_builder/tools/voltage_sequence/voltage_sequence.py
+++ b/quam_builder/tools/voltage_sequence/voltage_sequence.py
@@ -722,12 +722,18 @@ class VoltageSequence:
                 else 0.5
             )
 
+            # Determine channel-specific max_voltage to use, based on attenuation (but without mutating the loop max_voltage)
+            channel_max_voltage = max_voltage
             if self.gate_set.adjust_for_attenuation and hasattr(channel_obj, "attenuation"):
                 attenuation_scale = 10 ** (channel_obj.attenuation / 20)
-                if max_voltage * attenuation_scale > opx_voltage_limit:
-                    raise ValueError(
-                        f"Channel '{ch_name}' attenuation-corrected max_voltage of {max_voltage * attenuation_scale:.2f} exceeds OPX output limit of {opx_voltage_limit}"
+                if channel_max_voltage * attenuation_scale > opx_voltage_limit:
+                    new_max_voltage = opx_voltage_limit / attenuation_scale
+                    print(
+                        f"Channel '{ch_name}': attenuation-corrected max_voltage ({channel_max_voltage * attenuation_scale:.2f}) exceeds OPX output limit of {opx_voltage_limit}. "
+                        f"Using reduced max_voltage of {new_max_voltage:.4f} instead of supplied {channel_max_voltage:.4f}."
                     )
+                    channel_max_voltage = new_max_voltage
+
             tracker = self.state_trackers[ch_name]
             current_v = tracker.current_level
 
@@ -735,7 +741,7 @@ class VoltageSequence:
 
             if not is_qua_type(tracker.integrated_voltage) and not is_qua_type(current_v):
                 py_comp_amp, py_comp_dur = self._calculate_python_compensation_params(
-                    tracker, max_voltage
+                    tracker, channel_max_voltage
                 )
                 if py_comp_dur == 0:  # No pulse needed
                     tracker.current_level = py_comp_amp  # Should be 0.0
@@ -750,7 +756,7 @@ class VoltageSequence:
                 comp_amp_val, comp_dur_val = py_comp_amp, py_comp_dur
             else:
                 q_comp_amp, q_comp_dur_4ns = self._calculate_qua_compensation_params(
-                    tracker, max_voltage, channel_obj.name
+                    tracker, channel_max_voltage, channel_obj.name
                 )
                 delta_v_q = q_comp_amp - current_v
                 with if_(q_comp_dur_4ns > 0):


### PR DESCRIPTION
# Pull Request

## Description

Apply_compensation Pulse of VoltageSequence, checks if max_voltage * attenuation_scale goes beyond the OPX limit (0.5V or 2.5V) and raises an error. 
This change calculates a new max_voltage per channel that exceeds this limit and uses it instead of raising an error. There will be printed a notice that max_voltage is changed. 

## Type of Change

<!-- Mark relevant items with [x] -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ✅ Test addition/update
- [ ] 🎨 Code style/formatting update

## Related Issues

<!-- Link related issues using keywords: Closes #123, Fixes #456, Relates to #789 -->

## Checklist

### Code Quality

- [x] My code follows the project's style guidelines
- [ ] I have run `pre-commit` hooks and all checks pass (`pre-commit run --all-files`)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings

### Testing

- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass locally (`pytest`)
- [ ] I have tested my changes with the example scripts (if applicable)

### Documentation

- [ ] I have updated the documentation (if needed)
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md (if applicable)
- [ ] I have checked my code and corrected any misspellings

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include: -->
<!-- - What breaks -->
<!-- - Why the change was necessary -->
<!-- - Migration guide for users -->

**Does this PR introduce breaking changes?** <!-- Yes/No -->

## Testing Details

<!-- Describe how you tested your changes -->
<!-- Include: -->
<!-- - Test environment (Python version, OS, etc.) -->
<!-- - Steps to reproduce/verify -->
<!-- - Example code/scripts used for testing -->

## Screenshots/Examples

<!-- If applicable, add screenshots, code examples, or output samples -->

## Additional Context
This has popped up when using VideoMode where the interface to apply_compensation_pulse is hidden. 

## Reviewer Notes

<!-- Any specific areas you'd like reviewers to focus on? -->
