### PR TITLE
Refactor GaussianFiltered and SNZ pulses into quam-builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Changed
 Updated qualang-tools requirement `"qualang-tools>=0.22.0"`.
+- Added `scipy>=1.10` as a runtime dependency (required by the gaussian-filtered pulses).
 ### Added
 - Updated the TWPA component with isolation pump and added corresponding builder functions.
+- Added `GaussianFilteredSquarePulse` to `quam_builder.common.pulses` (mirrors `quam.components.pulses`).
+- Added `GaussianFilteredSymmetricBipolarPulse` and `SNZPulse` to `quam_builder.architecture.superconducting.components.pulses` (mirrors `quam.components.pulses`).
 ### Fixed
 - Fix the default behavior of `def initialize_qpu(self, isolation: bool = False, **kwargs):` in the SC `BaseQuam`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "xarray>=2024.7.0",
     "qcodes-contrib-drivers>=0.22.0",
     "qm-saas>=1.1.7",
+    "scipy>=1.10",
 ]
 
 [build-system]

--- a/quam_builder/architecture/superconducting/components/pulses.py
+++ b/quam_builder/architecture/superconducting/components/pulses.py
@@ -358,19 +358,13 @@ class GaussianFilteredSymmetricBipolarPulse(Pulse):
 
     @property
     def inferred_length(self) -> int:
-        return int(
-            np.ceil((self.pulse_length + self.padding_length) / 4) * 4
-        )
+        return int(np.ceil((self.pulse_length + self.padding_length) / 4) * 4)
 
     def waveform_function(self):
         if self.pulse_length <= 0:
-            raise ValueError(
-                "GaussianFilteredSymmetricBipolarPulse.pulse_length must be positive"
-            )
+            raise ValueError("GaussianFilteredSymmetricBipolarPulse.pulse_length must be positive")
         if self.pulse_length % 2 != 0:
-            raise ValueError(
-                "GaussianFilteredSymmetricBipolarPulse.pulse_length must be even"
-            )
+            raise ValueError("GaussianFilteredSymmetricBipolarPulse.pulse_length must be even")
         if self.padding_length < 0:
             raise ValueError(
                 "GaussianFilteredSymmetricBipolarPulse.post_zero_padding_length must be non-negative"

--- a/quam_builder/architecture/superconducting/components/pulses.py
+++ b/quam_builder/architecture/superconducting/components/pulses.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 import numpy as np
 
@@ -12,6 +13,8 @@ __all__ = [
     "BlackmanIntegralPulse",
     "FlatTopTanhPulse",
     "CosineBipolarPulse",
+    "GaussianFilteredSymmetricBipolarPulse",
+    "SNZPulse",
 ]
 
 
@@ -306,6 +309,200 @@ class CosineBipolarPulse(Pulse):
                 -A * halfcos(fall_len)[::-1],
             ]
         )
+
+        if self.axis_angle is not None:
+            p = p * np.exp(1j * self.axis_angle)
+
+        return p.tolist()
+
+
+@quam_dataclass
+class GaussianFilteredSymmetricBipolarPulse(Pulse):
+    """Symmetric bipolar square core with Gaussian filtering and peak renormalization.
+
+    The pre-filter layout over total ``length`` is
+    ``[zeros | +amplitude lobe | -amplitude lobe | zeros]`` where the two lobes are
+    equal length and opposite sign. ``gaussian_filter1d`` is then applied to the
+    entire array, the result is scaled so ``max(abs(waveform)) == amplitude``, and
+    optional ``axis_angle`` is applied.
+
+    Args:
+        pulse_length (int): Total samples in the bipolar core (sum of positive and
+            negative lobes). Must be positive and even.
+        post_zero_padding_length (int): Extra samples included in the total length
+            budget (default 0). Together with ``pulse_length``, total ``length`` is
+            ``ceil((pulse_length + post_zero_padding_length) / 4) * 4``. Remaining
+            samples are split symmetrically left/right as zeros before filtering.
+        digital_marker (str, list, optional): The digital marker to use for the pulse.
+        amplitude (float): Target peak magnitude in volts after filtering and
+            renormalization.
+        gaussian_filter_frequency_mhz (float): Frequency in MHz; filter width uses
+            sigma (samples) = sample_rate / (2 * pi * f_hz) with f_hz in Hz.
+        sample_rate (float): Sample rate in Hz used only for that sigma mapping
+            (default 1e9). Not used for IF modulation.
+        axis_angle (float, optional): IQ axis angle of the output pulse in radians.
+            If None (default), the pulse is meant for a single channel or the I port
+            of an IQ channel
+            If not None, the pulse is meant for an IQ channel (0 is X, pi/2 is Y).
+        length (int): Total waveform length in samples; inferred from
+            ``pulse_length + post_zero_padding_length`` rounded up to a multiple of 4.
+    """
+
+    pulse_length: int
+    padding_length: int = 0
+    amplitude: float
+    gaussian_filter_frequency_mhz: float
+    sample_rate: float = 1e9
+    axis_angle: float = None
+    length: int = "#./inferred_length"  # pyright: ignore
+
+    @property
+    def inferred_length(self) -> int:
+        return int(
+            np.ceil((self.pulse_length + self.padding_length) / 4) * 4
+        )
+
+    def waveform_function(self):
+        if self.pulse_length <= 0:
+            raise ValueError(
+                "GaussianFilteredSymmetricBipolarPulse.pulse_length must be positive"
+            )
+        if self.pulse_length % 2 != 0:
+            raise ValueError(
+                "GaussianFilteredSymmetricBipolarPulse.pulse_length must be even"
+            )
+        if self.padding_length < 0:
+            raise ValueError(
+                "GaussianFilteredSymmetricBipolarPulse.post_zero_padding_length must be non-negative"
+            )
+        if self.gaussian_filter_frequency_mhz <= 0:
+            raise ValueError(
+                "GaussianFilteredSymmetricBipolarPulse.gaussian_filter_frequency_mhz must be positive (MHz)"
+            )
+        if self.sample_rate <= 0:
+            raise ValueError(
+                "GaussianFilteredSymmetricBipolarPulse.sample_rate must be positive (Hz)"
+            )
+
+        if self.amplitude == 0:
+            return np.zeros(self.length, dtype=np.float64)
+
+        from scipy.ndimage import gaussian_filter1d
+
+        zero_pad_len = self.length - self.pulse_length
+        left_pad = zero_pad_len // 2
+        right_pad = zero_pad_len - left_pad
+
+        half_len = self.pulse_length // 2
+        env = np.concatenate(
+            (
+                np.zeros(left_pad, dtype=np.float64),
+                self.amplitude * np.ones(half_len, dtype=np.float64),
+                -self.amplitude * np.ones(half_len, dtype=np.float64),
+                np.zeros(right_pad, dtype=np.float64),
+            )
+        )
+
+        f_hz = self.gaussian_filter_frequency_mhz * 1e6
+        sigma = self.sample_rate / (2.0 * np.pi * f_hz)
+        env = gaussian_filter1d(env, sigma=sigma)
+
+        peak = float(np.max(np.abs(env)))
+        if peak > 0:
+            env = env * (self.amplitude / peak)
+        else:
+            env = np.zeros(self.length, dtype=np.float64)
+
+        if self.axis_angle is not None:
+            env = env * np.exp(1j * self.axis_angle)
+        return env
+
+
+@quam_dataclass
+class SNZPulse(Pulse):
+    """Sudden Net-Zero (SNZ) bipolar flux pulse (Di Carlo).
+
+    Generates a bipolar waveform with abrupt transitions between the two
+    lobes, separated by an idle period.  The waveform structure is::
+
+        [padding | +A flat | +B | idle(t_phi) | -B | -A flat | padding]
+
+    where ``t_phi_eff`` is decomposed into ``t_phi`` and ``B/A`` using the
+    same mapping as the SNZ calibration scripts:
+
+        t_phi = floor(t_phi_eff / 2) * 2
+        B/A = 1 - (t_phi_eff - t_phi) / 2
+
+    The single B / -B samples sit at the boundary between each flat section
+    and the idle gap, corresponding to the last/first sampling points of the
+    positive/negative lobes in the Di Carlo SNZ protocol.
+
+    The total flat duration (both halves combined) is ``flat_length``.  Each
+    half is ``flat_length // 2`` samples, so ``flat_length`` should be even.
+    Args:
+        amplitude (float): Peak amplitude of the flat sections (V).
+        flat_length (int): Total flat-section duration in samples, split
+            equally between positive and negative halves.  Should be even.
+        t_phi_eff (float): Effective idle time between the two lobes in
+            samples (ns at 1 GSa/s). Can be 0 for no idle gap.
+        padding (int): Zero-padding added to each side of the pulse
+            (samples).  Default is 0.
+        axis_angle (float, optional): IQ axis angle in radians.  If None,
+            the pulse targets a single channel or the I port of an IQ
+            channel.
+        length (int): Total waveform length in samples; auto-inferred from
+            the other parameters and rounded up to a multiple of 4.
+    """
+
+    amplitude: float
+    flat_length: int
+    t_phi_eff: float = 0.0
+    padding: int = 0
+    axis_angle: float = None
+    length: int = "#./inferred_length"  # pyright: ignore
+
+    @property
+    def t_phi(self) -> int:
+        if self.t_phi_eff < 0:
+            raise ValueError("SNZPulse.t_phi_eff must be non-negative")
+        return int(math.floor(self.t_phi_eff / 2.0)) * 2
+
+    @property
+    def b_over_a_ratio(self) -> float:
+        return 1.0 - (self.t_phi_eff - self.t_phi) / 2.0
+
+    @property
+    def inferred_length(self) -> int:
+        raw = 2 * self.padding + self.flat_length + 2 + self.t_phi
+        return int(np.ceil(raw / 4) * 4)
+
+    def waveform_function(self):
+        if self.flat_length <= 0:
+            raise ValueError("SNZPulse.flat_length must be positive")
+        if self.flat_length % 2 != 0:
+            raise ValueError(
+                f"SNZPulse.flat_length={self.flat_length} must be even to "
+                "split equally into positive and negative halves."
+            )
+        if self.padding < 0:
+            raise ValueError("SNZPulse.padding must be non-negative")
+
+        A = float(self.amplitude)
+        half = self.flat_length // 2
+        B = A * self.b_over_a_ratio
+
+        flat_pos = A * np.ones(half)
+        flat_neg = -A * np.ones(half)
+        idle = np.zeros(self.t_phi)
+
+        core = np.concatenate([flat_pos, [B], idle, [-B], flat_neg])
+
+        core_len = len(core)
+        total_pad = self.length - core_len
+        left_pad = total_pad // 2
+        right_pad = total_pad - left_pad
+
+        p = np.concatenate([np.zeros(left_pad), core, np.zeros(right_pad)])
 
         if self.axis_angle is not None:
             p = p * np.exp(1j * self.axis_angle)

--- a/quam_builder/architecture/superconducting/components/pulses.py
+++ b/quam_builder/architecture/superconducting/components/pulses.py
@@ -329,9 +329,9 @@ class GaussianFilteredSymmetricBipolarPulse(Pulse):
     Args:
         pulse_length (int): Total samples in the bipolar core (sum of positive and
             negative lobes). Must be positive and even.
-        post_zero_padding_length (int): Extra samples included in the total length
+        padding_length (int): Extra samples included in the total length
             budget (default 0). Together with ``pulse_length``, total ``length`` is
-            ``ceil((pulse_length + post_zero_padding_length) / 4) * 4``. Remaining
+            ``ceil((pulse_length + padding_length) / 4) * 4``. Remaining
             samples are split symmetrically left/right as zeros before filtering.
         digital_marker (str, list, optional): The digital marker to use for the pulse.
         amplitude (float): Target peak magnitude in volts after filtering and
@@ -345,7 +345,7 @@ class GaussianFilteredSymmetricBipolarPulse(Pulse):
             of an IQ channel
             If not None, the pulse is meant for an IQ channel (0 is X, pi/2 is Y).
         length (int): Total waveform length in samples; inferred from
-            ``pulse_length + post_zero_padding_length`` rounded up to a multiple of 4.
+            ``pulse_length + padding_length`` rounded up to a multiple of 4.
     """
 
     pulse_length: int
@@ -367,7 +367,7 @@ class GaussianFilteredSymmetricBipolarPulse(Pulse):
             raise ValueError("GaussianFilteredSymmetricBipolarPulse.pulse_length must be even")
         if self.padding_length < 0:
             raise ValueError(
-                "GaussianFilteredSymmetricBipolarPulse.post_zero_padding_length must be non-negative"
+                "GaussianFilteredSymmetricBipolarPulse.padding_length must be non-negative"
             )
         if self.gaussian_filter_frequency_mhz <= 0:
             raise ValueError(

--- a/quam_builder/common/pulses.py
+++ b/quam_builder/common/pulses.py
@@ -189,9 +189,7 @@ class GaussianFilteredSquarePulse(Pulse):
 
     @property
     def inferred_length(self) -> int:
-        return int(
-            np.ceil((self.pulse_length + self.padding_length) / 4) * 4
-        )
+        return int(np.ceil((self.pulse_length + self.padding_length) / 4) * 4)
 
     def waveform_function(self):
         if self.pulse_length <= 0:

--- a/quam_builder/common/pulses.py
+++ b/quam_builder/common/pulses.py
@@ -7,6 +7,7 @@ __all__ = [
     "GaussianPulse",
     "FlatTopGaussianPulse",
     "FlatTopCosinePulse",
+    "GaussianFilteredSquarePulse",
 ]
 
 
@@ -131,3 +132,105 @@ class FlatTopCosinePulse(Pulse):
         if self.axis_angle is not None:
             wf = wf * np.exp(1j * self.axis_angle)
         return wf
+
+
+@quam_dataclass
+class GaussianFilteredSquarePulse(Pulse):
+    """Square core with symmetric zero pads, then 1D Gaussian filter, peak-renormalized.
+
+    Zeros are placed left and right so the pre-filter layout is
+    ``[zeros | amplitude plateau | zeros]`` over total ``length``, then
+    ``gaussian_filter1d`` is applied to the **entire** array, then the real envelope
+    is scaled so its peak equals ``amplitude``, then optional ``axis_angle``.
+
+    Args:
+        pulse_length (int): Samples in the constant-amplitude **core** of the
+            pre-filter layout (between symmetric zero pads), not the length of a
+            separately filtered segment.
+        post_zero_padding_length (int): Extra samples included in the total length
+            budget (default 0). Together with ``pulse_length``, total ``length`` is
+            ``ceil((pulse_length + post_zero_padding_length) / 4) * 4``. Remaining
+            samples relative to the core are filled with zeros split symmetrically
+            left and right before filtering.
+        digital_marker (str, list, optional): The digital marker to use for the pulse.
+        amplitude (float): Peak amplitude in volts; after filtering, the real envelope
+            is scaled by a global gain so its maximum equals this value.
+        gaussian_filter_frequency_mhz (float): Frequency in MHz; filter width uses
+            sigma (samples) = sample_rate / (2 * pi * f_hz) with f_hz in Hz.
+        sample_rate (float): Sample rate in Hz used only for that sigma mapping
+            (default 1e9). Not used for IF modulation.
+        axis_angle (float, optional): IQ axis angle of the output pulse in radians.
+            If None (default), the pulse is meant for a single channel or the I port
+            of an IQ channel
+            If not None, the pulse is meant for an IQ channel (0 is X, pi/2 is Y).
+        length (int): Total waveform length in samples; inferred from
+            ``pulse_length + post_zero_padding_length`` rounded up to a multiple of 4.
+
+    Note:
+        Padded regions are **not** exactly zero after filtering; the Gaussian kernel
+        spreads energy from the plateau into the flanks.
+
+        With ``f_hz = gaussian_filter_frequency_mhz * 1e6``, the Gaussian width in
+        samples is ``sigma = sample_rate / (2 * pi * f_hz)``. As a rule of thumb,
+        aim for each symmetric flank (roughly half of ``length - pulse_length``) to
+        be at least on the order of **~5 sigma** so the smoothed waveform can decay
+        toward the window edges; increase ``post_zero_padding_length`` (and thus
+        inferred ``length``) if needed. Too little padding can leave significant
+        amplitude at the first or last samples. This is guidance only, not enforced.
+    """
+
+    pulse_length: int
+    padding_length: int = 0
+    amplitude: float
+    gaussian_filter_frequency_mhz: float
+    sample_rate: float = 1e9
+    axis_angle: float = None
+    length: int = "#./inferred_length"  # pyright: ignore
+
+    @property
+    def inferred_length(self) -> int:
+        return int(
+            np.ceil((self.pulse_length + self.padding_length) / 4) * 4
+        )
+
+    def waveform_function(self):
+        if self.pulse_length <= 0:
+            raise ValueError("GaussianFilteredSquarePulse.pulse_length must be positive")
+        if self.padding_length < 0:
+            raise ValueError(
+                "GaussianFilteredSquarePulse.post_zero_padding_length must be non-negative"
+            )
+        if self.gaussian_filter_frequency_mhz <= 0:
+            raise ValueError(
+                "GaussianFilteredSquarePulse.gaussian_filter_frequency_mhz must be positive (MHz)"
+            )
+        if self.sample_rate <= 0:
+            raise ValueError("GaussianFilteredSquarePulse.sample_rate must be positive (Hz)")
+
+        if self.amplitude == 0:
+            return np.zeros(self.length, dtype=np.float64)
+
+        from scipy.ndimage import gaussian_filter1d
+
+        zero_pad_len = self.length - self.pulse_length
+        left_pad = zero_pad_len // 2
+        right_pad = zero_pad_len - left_pad
+        env = np.concatenate(
+            (
+                np.zeros(left_pad, dtype=np.float64),
+                self.amplitude * np.ones(self.pulse_length, dtype=np.float64),
+                np.zeros(right_pad, dtype=np.float64),
+            )
+        )
+        f_hz = self.gaussian_filter_frequency_mhz * 1e6
+        sigma = self.sample_rate / (2.0 * np.pi * f_hz)
+        env = gaussian_filter1d(env, sigma=sigma)
+        peak = float(np.max(np.abs(env)))
+        if peak > 0:
+            env = env * (abs(self.amplitude) / peak)
+        else:
+            env = np.zeros(self.length, dtype=np.float64)
+
+        if self.axis_angle is not None:
+            env = env * np.exp(1j * self.axis_angle)
+        return env


### PR DESCRIPTION
## Summary

Mirrors three pulse classes from `quam/quam/components/pulses.py` into quam-builder, following the precedent set by #112 (copy semantics — classes remain importable from `quam.components.pulses`).

- `GaussianFilteredSquarePulse` → `quam_builder.common.pulses`
- `GaussianFilteredSymmetricBipolarPulse` → `quam_builder.architecture.superconducting.components.pulses`
- `SNZPulse` → `quam_builder.architecture.superconducting.components.pulses`

Adds `scipy>=1.10` as a runtime dependency (required by the gaussian-filtered pulses' `scipy.ndimage.gaussian_filter1d` call).

## Scope of changes

4 files changed, +304 / -0:

- `quam_builder/common/pulses.py` (+103): added `GaussianFilteredSquarePulse` verbatim and extended `__all__`.
- `quam_builder/architecture/superconducting/components/pulses.py` (+197): added `import math`, `GaussianFilteredSymmetricBipolarPulse`, `SNZPulse`, and extended `__all__`.
- `pyproject.toml` (+1): added `scipy>=1.10` to `[project].dependencies`.
- `CHANGELOG.md` (+3): noted the three new pulses and the new scipy runtime dep under `[Unreleased]`.

## Explicitly NOT touched

Per design discussion ahead of the change:

- `quam/quam/components/pulses.py` — left intact; the three classes remain importable from `quam.components.pulses` (copy semantics, matching commit `dbe7c86` / PR #112).
- `quam/tests/components/pulses/test_pulses.py` — no test duplication in `quam-builder/tests` (matches prior precedent: no equivalent pulse tests exist there for previously-copied SC pulses).
- `quam/docs/gaussian_filtered_pulses_demo.md` and `quam/docs/_generate_gf_plots.py` — left intact; no docs added to quam-builder.
- `quam_builder/common/__init__.py` — left as `from . import pulses`; not switched to a star-export.
- `quam_builder/builder/superconducting/add_default_pulses.py` — no new `add_<X>_pulses(...)` helpers.
- `qualibration_graphs/superconducting/quam_config/populate_soprano.py` — `SNZPulse` import stays pointing at `quam.components.pulses`.
- No class renames; no deprecation warnings; no state.json backward-compat shims.

## Result for callers

The three classes are now importable from **both** `quam.components.pulses` and the new quam-builder locations, with byte-identical behavior. `SNZPulse` is also reachable via the existing star re-export in `quam_builder/architecture/superconducting/components/__init__.py`.

## Test plan

- [x] Imports resolve from new locations (`quam_builder.common.pulses`, `quam_builder.architecture.superconducting.components.pulses`).
- [x] Star re-export picks up `SNZPulse` via `quam_builder.architecture.superconducting.components`.
- [x] Waveforms `np.array_equal` against quam originals for all three classes with identical constructor args (`GaussianFilteredSquarePulse`, `GaussianFilteredSymmetricBipolarPulse`, `SNZPulse`); inferred `length`, `t_phi`, and `b_over_a_ratio` also match.
- [x] Reproduced quam test behaviors against the migrated classes:
  - `GaussianFilteredSquarePulse` peak-renormalizes negative amplitudes (peak ≈ |amplitude|).
  - `SNZPulse` raises `ValueError` for `t_phi_eff < 0` and decomposes `t_phi_eff=3.4` into `(t_phi=2, b/a≈0.3)`.
  - `GaussianFilteredSymmetricBipolarPulse` has net area `~1e-16` (numerically zero).
- [x] Pulse-relevant non-`quantum_dots` tests in `quam-builder/tests` still pass (`11 passed, 1 skipped`).
- [ ] CI green.

## Notes for reviewers

- The `from scipy.ndimage import gaussian_filter1d` import is kept lazy inside `waveform_function`, matching the source in quam. The new `scipy>=1.10` runtime dep is what actually makes that import safe to rely on.
- `import math` was added to `quam_builder/architecture/superconducting/components/pulses.py` because `SNZPulse.t_phi` uses `math.floor`.
- Source line ranges in `quam/quam/components/pulses.py` for the copy: `GaussianFilteredSquarePulse` 674-772, `GaussianFilteredSymmetricBipolarPulse` 776-874, `SNZPulse` 1435-1523.
