### PR TITLE
feat: moving-qubit selection on CZGate and readout_GEF active reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Changed
-Updated qualang-tools requirement `"qualang-tools>=0.22.0"`.
+- Updated qualang-tools requirement `"qualang-tools>=0.22.0"`.
+- **BREAKING:** `CZGate` renamed `flux_pulse_control` → `flux_pulse_qubit`, `flux_pulse_control_label` → `flux_pulse_qubit_label`, and the `apply()` parameters `amplitude_scale_control` → `amplitude_scale_qubit` and `duration_control` → `duration_qubit`. The moving qubit is now chosen via `qubit_pair.moving_qubit`.
 ### Added
 - Updated the TWPA component with isolation pump and added corresponding builder functions.
 - `FluxTunableTransmonPair.moving_qubit` (`Literal["control", "target"]`, default `"control"`) selects which qubit carries the flux pulse during two-qubit gates.
+- `CZGate` now reads `qubit_pair.moving_qubit` to play the flux pulse on either the control or the target qubit.
 ### Fixed
 - Fix the default behavior of `def initialize_qpu(self, isolation: bool = False, **kwargs):` in the SC `BaseQuam`.
+- `CZGate.apply()` now includes the tunable coupler channel in the initial and final `align()` calls, so coupler pulses no longer drift relative to the qubits.
 
 ## [0.3.0] - 2026-03-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Updated qualang-tools requirement `"qualang-tools>=0.22.0"`.
 ### Added
 - Updated the TWPA component with isolation pump and added corresponding builder functions.
+- `FluxTunableTransmonPair.moving_qubit` (`Literal["control", "target"]`, default `"control"`) selects which qubit carries the flux pulse during two-qubit gates.
 ### Fixed
 - Fix the default behavior of `def initialize_qpu(self, isolation: bool = False, **kwargs):` in the SC `BaseQuam`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Updated qualang-tools requirement `"qualang-tools>=0.22.0"`.
 - **BREAKING:** `CZGate` renamed `flux_pulse_control` → `flux_pulse_qubit`, `flux_pulse_control_label` → `flux_pulse_qubit_label`, and the `apply()` parameters `amplitude_scale_control` → `amplitude_scale_qubit` and `duration_control` → `duration_qubit`. The moving qubit is now chosen via `qubit_pair.moving_qubit`.
+- **BREAKING:** `BaseTransmon.readout_state_gef` default `pulse_name` changed from `"readout"` to `"readout_GEF"`. `add_default_transmon_pulses` now seeds a matching `readout_GEF` operation, so default-pulse users are unaffected; callers using custom resonator operations may need to either pass `pulse_name="readout"` explicitly or define a `readout_GEF` operation on their resonator.
 ### Added
 - Updated the TWPA component with isolation pump and added corresponding builder functions.
 - `FluxTunableTransmonPair.moving_qubit` (`Literal["control", "target"]`, default `"control"`) selects which qubit carries the flux pulse during two-qubit gates.
 - `CZGate` now reads `qubit_pair.moving_qubit` to play the flux pulse on either the control or the target qubit.
+- Default `readout_GEF` `SquareReadoutPulse` added to transmon resonators by `add_default_transmon_pulses` so `readout_state_gef` works out of the box.
 ### Fixed
 - Fix the default behavior of `def initialize_qpu(self, isolation: bool = False, **kwargs):` in the SC `BaseQuam`.
 - `CZGate.apply()` now includes the tunable coupler channel in the initial and final `align()` calls, so coupler pulses no longer drift relative to the qubits.
+- `BaseTransmon.reset_qubit_active_gef` now passes `keep_phase=True` to all `update_frequency` calls, preserving the qubit drive phase across the f12 detour during GEF active reset.
 
 ## [0.3.0] - 2026-03-31
 ### Added

--- a/quam_builder/architecture/superconducting/custom_gates/flux_tunable_transmon_pair/two_qubit_gates.py
+++ b/quam_builder/architecture/superconducting/custom_gates/flux_tunable_transmon_pair/two_qubit_gates.py
@@ -232,9 +232,9 @@ class CZGate(QubitPairMacro):
         align(*channel_names)
 
         # Spectator qubit flux pulses
-        for qubit_name, spectator_qubit in zip(self.spectator_qubits.keys(), spectator_qubits_list):
-            if qubit_name in spectator_pulse_names:
-                spectator_qubit.z.play(spectator_pulse_names[qubit_name])
+        for qubit_name, pulse_name in spectator_pulse_names.items():
+            if qubit_name in self.spectator_qubits:
+                self.spectator_qubits[qubit_name].z.play(pulse_name)
 
         # Moving qubit flux
         moving_qubit = (

--- a/quam_builder/architecture/superconducting/custom_gates/flux_tunable_transmon_pair/two_qubit_gates.py
+++ b/quam_builder/architecture/superconducting/custom_gates/flux_tunable_transmon_pair/two_qubit_gates.py
@@ -54,7 +54,7 @@ class CZGate(QubitPairMacro):
          Collection of gate fidelity (e.g. fidelity["RB"]=xx, fidelity["XEB"]=xx).
     extras: Dict[str, Any]
          Additional attributes for the CZGate.
-    duration_control: ScalarInt
+    duration_qubit: ScalarInt
          Optional duration override for the moving qubit flux pulse.
 
     Spectator Qubits
@@ -178,7 +178,7 @@ class CZGate(QubitPairMacro):
 
     fidelity: dict[str, Any] = field(default_factory=dict)
     extras: dict[str, Any] = field(default_factory=dict)
-    duration_control: ScalarInt = None
+    duration_qubit: ScalarInt = None
 
     @property
     def flux_pulse_qubit_label(self) -> str:

--- a/quam_builder/architecture/superconducting/custom_gates/flux_tunable_transmon_pair/two_qubit_gates.py
+++ b/quam_builder/architecture/superconducting/custom_gates/flux_tunable_transmon_pair/two_qubit_gates.py
@@ -71,7 +71,7 @@ class CZGate(QubitPairMacro):
       qubit instances that will be controlled during the gate.
     - ``spectator_qubits_control``: Dictionary mapping the same qubit names (str) to Pulse objects.
       These pulses are applied to the spectator qubits' Z (flux) lines simultaneously with the
-      control qubit flux pulse.
+      moving qubit flux pulse.
     - ``spectator_qubits_phase_shift``: Dictionary mapping qubit names (str) to phase shift values
       (float, in units of 2π). These frame rotations are applied to the spectator qubits after
       the flux pulses, similar to phase_shift_control and phase_shift_target.
@@ -103,8 +103,8 @@ class CZGate(QubitPairMacro):
     }
 
     # When apply() is called, spectator qubits will:
-    # 1. Be aligned with control and target qubits
-    # 2. Have their flux pulses played in parallel with the control qubit pulse
+    # 1. Be aligned with all qubit and coupler channels
+    # 2. Have their flux pulses played in parallel with the moving qubit flux pulse
     # 3. Receive phase corrections after the gate
     cz_gate.apply()
     ```

--- a/quam_builder/architecture/superconducting/custom_gates/flux_tunable_transmon_pair/two_qubit_gates.py
+++ b/quam_builder/architecture/superconducting/custom_gates/flux_tunable_transmon_pair/two_qubit_gates.py
@@ -1,7 +1,8 @@
-from typing import Union, Any
+from typing import Any, Union
 from dataclasses import field
 
 import numpy as np
+from qm.qua import align
 
 from quam.components.macro import QubitPairMacro
 from quam.components.pulses import Pulse
@@ -30,15 +31,17 @@ class CZGate(QubitPairMacro):
     flux‑tunable transmon pair (optionally mediated by a tunable coupler).
 
     The CZGate coordinates:
-    1. A Z/flux pulse applied to the control qubit.
+    1. A Z/flux pulse applied to the "moving" qubit of the pair, selected by
+       ``qubit_pair.moving_qubit`` (``"control"`` or ``"target"``).
     2. (Optionally) a simultaneous flux pulse on a tunable coupler.
     3. Frame (virtual Z) phase corrections on control and target qubits.
     4. A final alignment between the involved elements.
 
     Attributes
     ----------
-    flux_pulse_control : Union[Pulse, str]
-         Pulse (or its name) applied on the control qubit Z (flux) line to enact the interaction.
+    flux_pulse_qubit : Union[Pulse, str]
+         Pulse (or its name) applied on the moving qubit's Z (flux) line to enact the
+         interaction. The moving qubit is selected by ``qubit_pair.moving_qubit``.
     coupler_flux_pulse : Pulse | None
          Optional pulse applied to the tunable coupler during the gate (None for fixed coupler).
     phase_shift_control : float
@@ -52,7 +55,7 @@ class CZGate(QubitPairMacro):
     extras: Dict[str, Any]
          Additional attributes for the CZGate.
     duration_control: ScalarInt
-         Optional duration override for the control qubit flux pulse.
+         Optional duration override for the moving qubit flux pulse.
 
     Spectator Qubits
     ----------------
@@ -118,23 +121,23 @@ class CZGate(QubitPairMacro):
 
     Properties
     ----------
-    flux_pulse_control_label : str
-         Resolved (final) label of the control qubit flux pulse (name extraction via get_pulse_name).
+    flux_pulse_qubit_label : str
+         Resolved (final) label of the moving qubit flux pulse (name extraction via get_pulse_name).
     coupler_flux_pulse_label : str
          Resolved (final) label of the coupler pulse (if provided).
 
     Methods
     -------
-    apply(*, amplitude_scale_control=None, amplitude_scale_coupler=None,
-            duration_control=None, phase_shift_control=None, phase_shift_target=None, **kwargs) -> None
+    apply(*, amplitude_scale_qubit=None, amplitude_scale_coupler=None,
+            duration_qubit=None, phase_shift_control=None, phase_shift_target=None, **kwargs) -> None
          Execute the CZ gate sequence.
          Parameters:
-              amplitude_scale_control : float | None
-                    Scalar multiplier for the control qubit flux pulse amplitude (passed through to play()).
+              amplitude_scale_qubit : float | None
+                    Scalar multiplier for the moving qubit flux pulse amplitude (passed through to play()).
               amplitude_scale_coupler : float | None
                     Scalar multiplier for the coupler pulse amplitude (only used if coupler_flux_pulse is set).
-              duration_control : int | None
-                    Optional duration override for the control qubit flux pulse.
+              duration_qubit : int | None
+                    Optional duration override for the moving qubit flux pulse.
               phase_shift_control : float | None
                     Per‑call override for control qubit frame rotation (2π units). If None, falls back
                     to phase_shift_control attribute (when significant).
@@ -145,14 +148,14 @@ class CZGate(QubitPairMacro):
                     Ignored auxiliary keyword arguments (accepted for interface compatibility).
 
          Behavior:
-              - Aligns all qubits (including spectator qubits) before playing to ensure simultaneous start.
-              - Plays control qubit flux pulse (with optional amplitude scaling and duration override).
+              - Aligns all qubits (including the coupler and spectator qubits) before playing to ensure simultaneous start.
+              - Plays the moving qubit's flux pulse (with optional amplitude scaling and duration override).
               - Plays spectator qubit flux pulses in parallel.
               - Optionally plays coupler pulse in parallel.
               - Aligns all resources.
               - Applies virtual Z frame rotations (overrides take precedence; negligible defaults skipped).
               - Applies spectator qubit phase shifts if configured.
-              - Performs a final align to ensure deterministic end-of-gate synchronization.
+              - Performs a final align (including the coupler) to ensure deterministic end-of-gate synchronization.
 
     Usage Notes
     -----------
@@ -163,7 +166,7 @@ class CZGate(QubitPairMacro):
       reconstructing pulse objects.
     """
 
-    flux_pulse_control: Union[Pulse, str]
+    flux_pulse_qubit: Union[Pulse, str]
     coupler_flux_pulse: Pulse = None
 
     phase_shift_control: float = 0.0
@@ -178,11 +181,14 @@ class CZGate(QubitPairMacro):
     duration_control: ScalarInt = None
 
     @property
-    def flux_pulse_control_label(self) -> str:
+    def flux_pulse_qubit_label(self) -> str:
+        qubit = (
+            self.qubit_control if self.qubit_pair.moving_qubit == "control" else self.qubit_target
+        )
         pulse = (
-            self.qubit_control.get_pulse(self.flux_pulse_control)
-            if isinstance(self.flux_pulse_control, str)
-            else self.flux_pulse_control
+            qubit.get_pulse(self.flux_pulse_qubit)
+            if isinstance(self.flux_pulse_qubit, str)
+            else self.flux_pulse_qubit
         )
         return get_pulse_name(pulse)
 
@@ -198,9 +204,9 @@ class CZGate(QubitPairMacro):
     def apply(
         self,
         *,
-        amplitude_scale_control=None,
+        amplitude_scale_qubit=None,
         amplitude_scale_coupler=None,
-        duration_control=None,
+        duration_qubit=None,
         phase_shift_control=None,
         phase_shift_target=None,
         **kwargs,
@@ -215,20 +221,31 @@ class CZGate(QubitPairMacro):
                 spectator_qubits_list.append(spectator_qubit)
                 spectator_pulse_names[qubit_name] = get_pulse_name(pulse)
 
-        # Align all qubits (including spectator qubits) before playing to ensure simultaneous start
-        align_list = [self.qubit_pair.qubit_target] + spectator_qubits_list
-        self.qubit_pair.qubit_control.align(align_list)
+        # Align all qubits (including coupler and spectator qubits) before playing to ensure simultaneous start
+        all_qubits = [
+            self.qubit_pair.qubit_control,
+            self.qubit_pair.qubit_target,
+        ] + spectator_qubits_list
+        channel_names = {ch.name for qubit in all_qubits for ch in qubit.channels.values()}
+        if hasattr(self.qubit_pair, "coupler") and self.qubit_pair.coupler is not None:
+            channel_names.add(self.qubit_pair.coupler.name)
+        align(*channel_names)
 
         # Spectator qubit flux pulses
         for qubit_name, spectator_qubit in zip(self.spectator_qubits.keys(), spectator_qubits_list):
             if qubit_name in spectator_pulse_names:
                 spectator_qubit.z.play(spectator_pulse_names[qubit_name])
 
-        # Control qubit flux
-        self.qubit_pair.qubit_control.z.play(
-            self.flux_pulse_control_label,
-            amplitude_scale=amplitude_scale_control,
-            duration=duration_control,
+        # Moving qubit flux
+        moving_qubit = (
+            self.qubit_pair.qubit_control
+            if self.qubit_pair.moving_qubit == "control"
+            else self.qubit_pair.qubit_target
+        )
+        moving_qubit.z.play(
+            self.flux_pulse_qubit_label,
+            amplitude_scale=amplitude_scale_qubit,
+            duration=duration_qubit,
         )
 
         # Coupler flux
@@ -257,5 +274,8 @@ class CZGate(QubitPairMacro):
             if qubit_name in self.spectator_qubits and np.abs(phase_shift) > 1e-6:
                 self.spectator_qubits[qubit_name].xy.frame_rotation_2pi(phase_shift)
 
-        # Final alignment
-        self.qubit_pair.qubit_control.align([self.qubit_pair.qubit_target] + spectator_qubits_list)
+        # Final alignment (includes coupler if present)
+        final_channel_names = {ch.name for qubit in all_qubits for ch in qubit.channels.values()}
+        if hasattr(self.qubit_pair, "coupler") and self.qubit_pair.coupler is not None:
+            final_channel_names.add(self.qubit_pair.coupler.name)
+        align(*final_channel_names)

--- a/quam_builder/architecture/superconducting/qubit/base_transmon.py
+++ b/quam_builder/architecture/superconducting/qubit/base_transmon.py
@@ -136,9 +136,7 @@ class BaseTransmon(Qubit):
         QM: QuantumMachine,
         calibrate_drive: bool = True,
         calibrate_resonator: bool = True,
-    ) -> Tuple[
-        Union[None, MixerCalibrationResults], Union[None, MixerCalibrationResults]
-    ]:
+    ) -> Tuple[Union[None, MixerCalibrationResults], Union[None, MixerCalibrationResults]]:
         """Calibrate the Octave channels (xy and resonator) linked to this transmon for the LO frequency, intermediate
         frequency and Octave gain as defined in the state.
 
@@ -199,9 +197,7 @@ class BaseTransmon(Qubit):
                     f"The gate '{gate}_{gate_shape}' is not part of the existing operations for {self.xy.name} --> {self.xy.operations.keys()}."
                 )
 
-    def readout_state(
-        self, state, pulse_name: str = "readout", threshold: Optional[float] = None
-    ):
+    def readout_state(self, state, pulse_name: str = "readout", threshold: Optional[float] = None):
         """
         Perform a readout of the qubit state using the specified pulse.
 
@@ -263,9 +259,7 @@ class BaseTransmon(Qubit):
         else:
             if log_callable is None:
                 log_callable = getLogger(__name__).warning
-            log_callable(
-                "For simulating the QUA program, the qubit reset has been skipped."
-            )
+            log_callable("For simulating the QUA program, the qubit reset has been skipped.")
 
     def reset_qubit_thermal(self):
         """
@@ -365,22 +359,23 @@ class BaseTransmon(Qubit):
                     success, success + 1
                 )  # we need to measure 'g' two times in a row to increase our confidence
             with if_(res_ar == 1):
-                update_frequency(self.xy.name, int(self.xy.intermediate_frequency))
+                update_frequency(self.xy.name, int(self.xy.intermediate_frequency), keep_phase=True)
                 self.xy.play(pi_01_pulse_name)
                 assign(success, 0)
             with if_(res_ar == 2):
                 update_frequency(
                     self.xy.name,
                     int(self.xy.intermediate_frequency - self.anharmonicity),
+                    keep_phase=True,
                 )
                 self.xy.play(pi_12_pulse_name)
-                update_frequency(self.xy.name, int(self.xy.intermediate_frequency))
+                update_frequency(self.xy.name, int(self.xy.intermediate_frequency), keep_phase=True)
                 self.xy.play(pi_01_pulse_name)
                 assign(success, 0)
             self.align()
             assign(attempts, attempts + 1)
 
-    def readout_state_gef(self, state: QuaVariable, pulse_name: str = "readout"):
+    def readout_state_gef(self, state: QuaVariable, pulse_name: str = "readout_GEF"):
         """
         Perform a GEF state readout using the specified pulse and update the state variable.
 
@@ -391,7 +386,7 @@ class BaseTransmon(Qubit):
 
         Args:
             state (QuaVariableBool): The variable to store the readout state (0 for 'g', 1 for 'e', 2 for 'f').
-            pulse_name (str, optional): The name of the pulse to use for the readout. Defaults to "readout".
+            pulse_name (str, optional): The name of the pulse to use for the readout. Defaults to "readout_GEF".
 
         Returns:
             None
@@ -401,10 +396,7 @@ class BaseTransmon(Qubit):
         diff = declare(fixed, size=3)
 
         self.resonator.update_frequency(
-            int(
-                self.resonator.intermediate_frequency
-                + self.resonator.GEF_frequency_shift
-            )
+            int(self.resonator.intermediate_frequency + self.resonator.GEF_frequency_shift)
         )
         self.resonator.measure(pulse_name, qua_vars=(I, Q))
         self.resonator.update_frequency(self.resonator.intermediate_frequency)

--- a/quam_builder/architecture/superconducting/qubit_pair/flux_tunable_transmon_pair.py
+++ b/quam_builder/architecture/superconducting/qubit_pair/flux_tunable_transmon_pair.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional, Union, List
+from typing import Dict, Any, Literal, Optional, Union, List
 from dataclasses import field
 from qm.qua import align, wait
 
@@ -23,6 +23,8 @@ class FluxTunableTransmonPair(QubitPair):
             Can be a string, or an integer in which case it will add `Channel._default_label`.
         qubit_control (FluxTunableTransmon): The control qubit of the pair.
         qubit_target (FluxTunableTransmon): The target qubit of the pair.
+        moving_qubit (Literal["control", "target"]): Which qubit carries the flux pulse during
+            two-qubit gates such as CZ. Defaults to "control" for backwards compatibility.
         coupler (Optional[TunableCoupler]): The tunable coupler component.
         detuning (Optional[float]): Flux amplitude required to bring the qubits to the same energy in V
         confusion (list): The readout confusion matrix.
@@ -38,6 +40,7 @@ class FluxTunableTransmonPair(QubitPair):
     id: Union[int, str]
     qubit_control: FluxTunableTransmon = None
     qubit_target: FluxTunableTransmon = None
+    moving_qubit: Literal["control", "target"] = "control"
     coupler: Optional[TunableCoupler] = None
 
     detuning: Optional[float] = None

--- a/quam_builder/builder/superconducting/add_default_pulses.py
+++ b/quam_builder/builder/superconducting/add_default_pulses.py
@@ -271,6 +271,7 @@ def add_default_transmon_pulses(transmon: Union[FixedFrequencyTransmon, FluxTuna
         * transmon.xy.operations["saturation"] = SquarePulse(amplitude=0.25, length=20 * u.us, axis_angle=0)
         * transmon.z.operations["const"] = SquarePulse(amplitude=0.1, length=100)
         * transmon.resonator.operations["readout"] = SquareReadoutPulse(length=2000, amplitude=0.01, threshold=0.0, digital_marker="ON")
+        * transmon.resonator.operations["readout_GEF"] = SquareReadoutPulse(length=2000, amplitude=0.01, threshold=0.0, digital_marker="ON")
 
     Args:
         transmon (Union[FixedFrequencyTransmon, FluxTunableTransmon]): The transmon qubit to which the pulses will be added.
@@ -288,6 +289,9 @@ def add_default_transmon_pulses(transmon: Union[FixedFrequencyTransmon, FluxTuna
     if hasattr(transmon, "resonator"):
         if transmon.resonator is not None:
             transmon.resonator.operations["readout"] = SquareReadoutPulse(
+                length=2000, amplitude=0.01, threshold=0.0, digital_marker="ON"
+            )
+            transmon.resonator.operations["readout_GEF"] = SquareReadoutPulse(
                 length=2000, amplitude=0.01, threshold=0.0, digital_marker="ON"
             )
 


### PR DESCRIPTION
# Pull Request

## Description

Ports three focused features from `refactor/add-moving-qubit` onto current `main` (the rest of that stale branch is intentionally left out):

1. **`FluxTunableTransmonPair.moving_qubit`** — new `Literal["control", "target"]` attribute (default `"control"`) declaring which qubit carries the flux pulse during two-qubit gates.
2. **`CZGate`** — now reads `qubit_pair.moving_qubit` to play the flux pulse on either the control or target qubit, and includes the tunable coupler channel in its pre-play and final `align()` calls (the coupler is a `SingleChannel`, not a `Qubit`, and was previously skipped by the qubit-based align). As part of this, `flux_pulse_control` / `amplitude_scale_control` / `duration_control` are renamed to `*_qubit` for semantic accuracy — **breaking**.
3. **`BaseTransmon` GEF readout** — `readout_state_gef` defaults to `pulse_name="readout_GEF"`, a matching default `readout_GEF` pulse is seeded by `add_default_transmon_pulses`, and `reset_qubit_active_gef` now uses `keep_phase=True` on its `update_frequency` calls.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related Issues

<!-- None -->

## Checklist

### Code Quality

- [x] My code follows the project's style guidelines
- [ ] I have run `pre-commit` hooks and all checks pass (`pre-commit run --all-files`) — only `black` was run; not full pre-commit
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

### Testing

- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally (`pytest`) — 111 passed, 3 skipped
- [ ] I have tested my changes with the example scripts (if applicable)

### Documentation

- [ ] I have updated the documentation (if needed)
- [x] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md (if applicable)
- [x] I have checked my code and corrected any misspellings

## Breaking Changes

**Does this PR introduce breaking changes?** Yes (two).

1. `CZGate` field/parameter rename:

   | Before | After |
   | --- | --- |
   | `flux_pulse_control` | `flux_pulse_qubit` |
   | `flux_pulse_control_label` | `flux_pulse_qubit_label` |
   | `apply(amplitude_scale_control=…)` | `apply(amplitude_scale_qubit=…)` |
   | `apply(duration_control=…)` | `apply(duration_qubit=…)` |

   Rationale: the flux pulse may now be played on either qubit of the pair (selected via `qubit_pair.moving_qubit`), so the `_control` suffix is no longer accurate. Migration: rename references in user code and in any persisted state JSON.

2. `BaseTransmon.readout_state_gef` default `pulse_name` changed from `"readout"` to `"readout_GEF"`.

   Rationale: GEF readout typically wants its own pulse (different power / discrimination thresholds). `add_default_transmon_pulses` now seeds a default `readout_GEF` operation, so users relying on the default pulse seeding are not affected. Users with custom resonator operations must either define a `readout_GEF` operation or pass `pulse_name="readout"` explicitly to `readout_state_gef`.

## Testing Details

- macOS, Python 3.11 venv built with `uv sync --frozen`.
- `uv run pytest tests/ -q` → 111 passed, 3 skipped, 0 failures (the `tests_against_server/` suite was skipped as it requires a live QM server connection).
- `uvx black==24.10.0 --line-length 100 --target-version py310 …` over the four touched files — clean.

## Additional Context

- Branched off current `main` (`dbe7c86`), not off `refactor/add-moving-qubit`, to avoid dragging in the ~3 months of unmerged refactors on that branch.
- Faithful port of the upstream alignment fix: the middle "Align all resources after playing pulses" call in `CZGate.apply` is intentionally left in its old qubit-based form (matches upstream `refactor/add-moving-qubit`); only the pre-play and final `align()` calls were upgraded to include the coupler.
- `CZGate.moving_qubit` (the redundant local attribute added by upstream PR #113) is intentionally **not** included; the pair owns the single source of truth and `CZGate.apply` reads `self.qubit_pair.moving_qubit`.
- Some pre-existing >100 char lines in `base_transmon.py` were reformatted by black as a side effect of running the formatter on the modified file — this is what pre-commit's black hook would produce on next touch.

## Reviewer Notes

- The CZGate rename is the highest-blast-radius change. Confirmed via grep that no other file in this repo references `flux_pulse_control`, `amplitude_scale_control`, or `duration_control`, so the in-repo blast radius is zero — but downstream users / persisted JSON will need to be updated.
- Please double-check the choice to leave the middle `align(...)` call unchanged. If you'd prefer fixing all three for consistency (the middle one has the same coupler-not-aligned bug), happy to follow up.