### PR TITLE
Refactor/pulses qd nv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,63 +1,104 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
 ### Changed
+
 - Updated qualang-tools requirement `"qualang-tools>=0.22.0"`.
 - **BREAKING:** `CZGate` renamed `flux_pulse_control` → `flux_pulse_qubit`, `flux_pulse_control_label` → `flux_pulse_qubit_label`, and the `apply()` parameters `amplitude_scale_control` → `amplitude_scale_qubit` and `duration_control` → `duration_qubit`. The moving qubit is now chosen via `qubit_pair.moving_qubit`.
 - **BREAKING:** `BaseTransmon.readout_state_gef` default `pulse_name` changed from `"readout"` to `"readout_GEF"`. `add_default_transmon_pulses` now seeds a matching `readout_GEF` operation, so default-pulse users are unaffected; callers using custom resonator operations may need to either pass `pulse_name="readout"` explicitly or define a `readout_GEF` operation on their resonator.
+
 ### Added
+
 - Updated the TWPA component with isolation pump and added corresponding builder functions.
 - `FluxTunableTransmonPair.moving_qubit` (`Literal["control", "target"]`, default `"control"`) selects which qubit carries the flux pulse during two-qubit gates.
 - `CZGate` now reads `qubit_pair.moving_qubit` to play the flux pulse on either the control or the target qubit.
 - Default `readout_GEF` `SquareReadoutPulse` added to transmon resonators by `add_default_transmon_pulses` so `readout_state_gef` works out of the box.
-Updated qualang-tools requirement `"qualang-tools>=0.22.0"`.
+  Updated qualang-tools requirement `"qualang-tools>=0.22.0"`.
 - Added `scipy>=1.10` as a runtime dependency (required by the gaussian-filtered pulses).
+
 ### Added
+
 - Updated the TWPA component with isolation pump and added corresponding builder functions.
 - Added `GaussianFilteredSquarePulse` to `quam_builder.common.pulses` (mirrors `quam.components.pulses`).
 - Added `GaussianFilteredSymmetricBipolarPulse` and `SNZPulse` to `quam_builder.architecture.superconducting.components.pulses` (mirrors `quam.components.pulses`).
+
+### Added
+
+- Updated the TWPA component with isolation pump and added corresponding builder functions.
+- Added `quam_builder/common/pulses.py` with general-purpose pulse classes (`GaussianPulse`, `FlatTopGaussianPulse`, `FlatTopCosinePulse`) shared across architectures.
+- Added superconducting-specific pulse classes to `architecture/superconducting/components/pulses.py`: `FlatTopBlackmanPulse`, `BlackmanIntegralPulse`, `FlatTopTanhPulse`, `CosineBipolarPulse`.
+
+### Changed
+
+- Updated qualang-tools requirement `"qualang-tools>=0.22.0"`.
+- Renamed `builder/superconducting/pulses.py` → `add_default_pulses.py` to clarify its role as a builder helper and avoid naming clash with the architecture-level `pulses.py`.
+- Renamed `builder/quantum_dots/pulses.py` → `add_default_pulses.py` and updated pulse imports to use explicit class imports; `GaussianPulse` now sourced from `quam_builder.common.pulses`.
+- Renamed `builder/nv_center/pulses.py` → `add_default_pulses.py` and switched to explicit class imports from `quam.components.pulses`.
+- Updated `architecture/quantum_dots/components/xy_drive.py` and `gate_set.py` to use explicit pulse class imports instead of the `pulses` module.
+
 ### Fixed
+
 - Fix the default behavior of `def initialize_qpu(self, isolation: bool = False, **kwargs):` in the SC `BaseQuam`.
 - `CZGate.apply()` now includes the tunable coupler channel in the initial and final `align()` calls, so coupler pulses no longer drift relative to the qubits.
 - `BaseTransmon.reset_qubit_active_gef` now passes `keep_phase=True` to all `update_frequency` calls, preserving the qubit drive phase across the f12 detour during GEF active reset.
 
 ## [0.3.0] - 2026-03-31
+
 ### Added
+
 - Added support for Python 3.13.
 - Add support for cloud-based QMM instances in `machine.connect()`
 - A custom QMM class can be specified in the network configuration, and enabled/disabled with the `use_custom_qmm` flag.
 - TWPA: add `pumpline_attenuation` and `signalline_attenuation` (float, optional) attributes.
 - BaseQuam , XYDriveBase and ReadoutResonatorBase: `extras` (dict) for additional QUAM-level attributes.
+
 ### Changed
+
 - FluxTunableQuam.set_all_fluxes: `target` is now optional; when `target=None`, settle and align are applied to all qubits.
+
 ### Fixed
+
 - NV center - fix invalid `SPCM` component.
 
 ## [0.2.0] - 2025-10-29
+
 ### Added
+
 - Complete architecture for single NV centers.
 - Macro class for the CZ gate on tunable transmons: `CZGate`
 - Add the `CZGate` fidelity and extras as dictionaries.
 - Architecture components for Quantum Dots: added support for `VoltageGate`, `GateSet`, `VoltageSequence`, `VirtualGateSet`, and `VirtualizationLayer`.
+
 ### Changed
+
 - Fixed dev dependencies and added tool.uv.prerelease=allow to the pyproject.toml file.
 
 ## [0.1.2] - 2025-08-06
+
 ### Added
+
 - tools - Added `power_tools.py` from qualibration-libs to remove the dependency.
+
 ### Fixed
+
 - Remove qualibrate and xarray from the requirements.
 - Fixed bug which created a self-reference when using external mixers.
 
 ## [0.1.1] - 2025-07-14
+
 ### Added
+
 - Optional `num_IQ_pairs` argument to `declare_qua_variables`.
 
 ## [0.1.0] - 2025-05-07
+
 ### Added
+
 - Architecture components for Flux Tunable Transmons.
 - Architecture components for Fixed Frequency Transmons.
 - Builder functions for the general QUAM wiring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,36 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-### Changed
-
-- Updated qualang-tools requirement `"qualang-tools>=0.22.0"`.
-- **BREAKING:** `CZGate` renamed `flux_pulse_control` → `flux_pulse_qubit`, `flux_pulse_control_label` → `flux_pulse_qubit_label`, and the `apply()` parameters `amplitude_scale_control` → `amplitude_scale_qubit` and `duration_control` → `duration_qubit`. The moving qubit is now chosen via `qubit_pair.moving_qubit`.
-- **BREAKING:** `BaseTransmon.readout_state_gef` default `pulse_name` changed from `"readout"` to `"readout_GEF"`. `add_default_transmon_pulses` now seeds a matching `readout_GEF` operation, so default-pulse users are unaffected; callers using custom resonator operations may need to either pass `pulse_name="readout"` explicitly or define a `readout_GEF` operation on their resonator.
-
 ### Added
 
 - Updated the TWPA component with isolation pump and added corresponding builder functions.
-- `FluxTunableTransmonPair.moving_qubit` (`Literal["control", "target"]`, default `"control"`) selects which qubit carries the flux pulse during two-qubit gates.
+- Added `quam_builder/common/pulses.py` with general-purpose pulse classes (`GaussianPulse`, `FlatTopGaussianPulse`, `FlatTopCosinePulse`, `GaussianFilteredSquarePulse`) shared across architectures.
+- Added superconducting-specific pulse classes to `architecture/superconducting/components/pulses.py`: `FlatTopBlackmanPulse`, `BlackmanIntegralPulse`, `FlatTopTanhPulse`, `CosineBipolarPulse`, `GaussianFilteredSymmetricBipolarPulse`, and `SNZPulse`.
+- Added `scipy>=1.10` as a runtime dependency (required by the gaussian-filtered pulses).
+- Added `FluxTunableTransmonPair.moving_qubit` (`Literal["control", "target"]`, default `"control"`) to select which qubit carries the flux pulse during two-qubit gates.
 - `CZGate` now reads `qubit_pair.moving_qubit` to play the flux pulse on either the control or the target qubit.
 - Default `readout_GEF` `SquareReadoutPulse` added to transmon resonators by `add_default_transmon_pulses` so `readout_state_gef` works out of the box.
-  Updated qualang-tools requirement `"qualang-tools>=0.22.0"`.
-- Added `scipy>=1.10` as a runtime dependency (required by the gaussian-filtered pulses).
-
-### Added
-
-- Updated the TWPA component with isolation pump and added corresponding builder functions.
-- Added `GaussianFilteredSquarePulse` to `quam_builder.common.pulses` (mirrors `quam.components.pulses`).
-- Added `GaussianFilteredSymmetricBipolarPulse` and `SNZPulse` to `quam_builder.architecture.superconducting.components.pulses` (mirrors `quam.components.pulses`).
-
-### Added
-
-- Updated the TWPA component with isolation pump and added corresponding builder functions.
-- Added `quam_builder/common/pulses.py` with general-purpose pulse classes (`GaussianPulse`, `FlatTopGaussianPulse`, `FlatTopCosinePulse`) shared across architectures.
-- Added superconducting-specific pulse classes to `architecture/superconducting/components/pulses.py`: `FlatTopBlackmanPulse`, `BlackmanIntegralPulse`, `FlatTopTanhPulse`, `CosineBipolarPulse`.
 
 ### Changed
 
-- Updated qualang-tools requirement `"qualang-tools>=0.22.0"`.
+- Updated qualang-tools requirement to `"qualang-tools>=0.22.0"`.
+- **BREAKING:** `CZGate` renamed `flux_pulse_control` → `flux_pulse_qubit`, `flux_pulse_control_label` → `flux_pulse_qubit_label`, and the `apply()` parameters `amplitude_scale_control` → `amplitude_scale_qubit` and `duration_control` → `duration_qubit`. The moving qubit is now chosen via `qubit_pair.moving_qubit`.
+- **BREAKING:** `BaseTransmon.readout_state_gef` default `pulse_name` changed from `"readout"` to `"readout_GEF"`. `add_default_transmon_pulses` now seeds a matching `readout_GEF` operation, so default-pulse users are unaffected; callers using custom resonator operations may need to either pass `pulse_name="readout"` explicitly or define a `readout_GEF` operation on their resonator.
 - Renamed `builder/superconducting/pulses.py` → `add_default_pulses.py` to clarify its role as a builder helper and avoid naming clash with the architecture-level `pulses.py`.
 - Renamed `builder/quantum_dots/pulses.py` → `add_default_pulses.py` and updated pulse imports to use explicit class imports; `GaussianPulse` now sourced from `quam_builder.common.pulses`.
 - Renamed `builder/nv_center/pulses.py` → `add_default_pulses.py` and switched to explicit class imports from `quam.components.pulses`.

--- a/quam_builder/architecture/quantum_dots/components/gate_set.py
+++ b/quam_builder/architecture/quantum_dots/components/gate_set.py
@@ -1,4 +1,5 @@
-from quam.components import QuantumComponent, pulses
+from quam.components import QuantumComponent
+from quam.components.pulses import SquarePulse
 from quam.components.channels import SingleChannel
 from quam.core import quam_dataclass
 from quam.core.macro import QuamMacro
@@ -105,15 +106,15 @@ class GateSet(QuantumComponent):
                 continue
             if hasattr(ch.opx_output, "output_mode"):
                 if ch.opx_output.output_mode == "amplified":
-                    ch.operations[DEFAULT_PULSE_NAME] = pulses.SquarePulse(
+                    ch.operations[DEFAULT_PULSE_NAME] = SquarePulse(
                         amplitude=1.25, length=MIN_PULSE_DURATION_NS
                     )
                 else:
-                    ch.operations[DEFAULT_PULSE_NAME] = pulses.SquarePulse(
+                    ch.operations[DEFAULT_PULSE_NAME] = SquarePulse(
                         amplitude=0.25, length=MIN_PULSE_DURATION_NS
                     )
             else:
-                ch.operations[DEFAULT_PULSE_NAME] = pulses.SquarePulse(
+                ch.operations[DEFAULT_PULSE_NAME] = SquarePulse(
                     amplitude=0.25, length=MIN_PULSE_DURATION_NS
                 )
 

--- a/quam_builder/architecture/quantum_dots/components/xy_drive.py
+++ b/quam_builder/architecture/quantum_dots/components/xy_drive.py
@@ -2,8 +2,10 @@ from typing import Dict, Optional
 
 
 from quam.core import quam_dataclass
-from quam.components import MWChannel, pulses
+from quam.components import MWChannel
 from quam.components.channels import IQChannel, MWChannel, SingleChannel
+from quam.components.pulses import Pulse, SquarePulse
+from quam_builder.common.pulses import GaussianPulse
 
 from quam_builder.tools.power_tools import (
     calculate_voltage_scaling_factor,
@@ -61,16 +63,16 @@ class XYDriveSingle(SingleChannel, XYDriveBase):
         super().__post_init__()
         if self.add_default_pulses:
             if "gaussian" not in self.operations:
-                self.operations["gaussian"] = pulses.GaussianPulse(
+                self.operations["gaussian"] = GaussianPulse(
                     length=100, amplitude=0.2, sigma=40
                 )
             if "pi" not in self.operations:
-                self.operations["pi"] = pulses.SquarePulse(length=104, amplitude=0.2)
+                self.operations["pi"] = SquarePulse(length=104, amplitude=0.2)
 
             if "pi_half" not in self.operations:
-                self.operations["pi_half"] = pulses.SquarePulse(length=52, amplitude=0.2)
+                self.operations["pi_half"] = SquarePulse(length=52, amplitude=0.2)
 
-    def add_pulse(self, name: str, pulse: pulses.Pulse) -> None:
+    def add_pulse(self, name: str, pulse: Pulse) -> None:
         """Add or update a pulse in the drive operations"""
         self.operations[name] = pulse
 
@@ -103,7 +105,7 @@ class XYDriveIQ(IQChannel, XYDriveBase):
         """
         return get_output_power_iq_channel(self, operation, Z)
 
-    def get_pulse(self, name: str) -> pulses.Pulse:
+    def get_pulse(self, name: str) -> Pulse:
         """Get a pulse from operations"""
         if name not in self.operations:
             raise ValueError(f"Pulse {name} not found in operations")

--- a/quam_builder/architecture/quantum_dots/components/xy_drive.py
+++ b/quam_builder/architecture/quantum_dots/components/xy_drive.py
@@ -63,9 +63,7 @@ class XYDriveSingle(SingleChannel, XYDriveBase):
         super().__post_init__()
         if self.add_default_pulses:
             if "gaussian" not in self.operations:
-                self.operations["gaussian"] = GaussianPulse(
-                    length=100, amplitude=0.2, sigma=40
-                )
+                self.operations["gaussian"] = GaussianPulse(length=100, amplitude=0.2, sigma=40)
             if "pi" not in self.operations:
                 self.operations["pi"] = SquarePulse(length=104, amplitude=0.2)
 

--- a/quam_builder/builder/nv_center/add_default_pulses.py
+++ b/quam_builder/builder/nv_center/add_default_pulses.py
@@ -2,7 +2,7 @@ from typing import Union
 
 import numpy as np
 from qualang_tools.units import unit
-from quam.components import pulses
+from quam.components.pulses import Pulse, SquarePulse, SquareReadoutPulse
 
 from quam_builder.architecture.nv_center.qubit import NVCenter
 from quam_builder.architecture.nv_center.qubit_pair import NVCenterPair
@@ -31,37 +31,37 @@ def add_Square_pulses(
         digital_marker (str, optional): The digital marker for the pulses. Defaults to None. Can be set to "ON".
     """
     if nv_center.xy is not None:
-        nv_center.xy.operations["x180_Square"] = pulses.SquarePulse(
+        nv_center.xy.operations["x180_Square"] = SquarePulse(
             length=length,
             amplitude=amplitude,
             digital_marker=digital_marker,
             axis_angle=0,
         )
-        nv_center.xy.operations["x90_Square"] = pulses.SquarePulse(
+        nv_center.xy.operations["x90_Square"] = SquarePulse(
             length="#../x180_Square/length",
             amplitude=amplitude / 2,
             digital_marker="#../x180_Square/digital_marker",
             axis_angle=0,
         )
-        nv_center.xy.operations["-x90_Square"] = pulses.SquarePulse(
+        nv_center.xy.operations["-x90_Square"] = SquarePulse(
             length="#../x180_Square/length",
             amplitude="#../x90_Square/amplitude",
             digital_marker="#../x180_Square/digital_marker",
             axis_angle=np.pi,
         )
-        nv_center.xy.operations["y180_Square"] = pulses.SquarePulse(
+        nv_center.xy.operations["y180_Square"] = SquarePulse(
             length="#../x180_Square/length",
             amplitude="#../x180_Square/amplitude",
             digital_marker="#../x180_Square/digital_marker",
             axis_angle=np.pi / 2,
         )
-        nv_center.xy.operations["y90_Square"] = pulses.SquarePulse(
+        nv_center.xy.operations["y90_Square"] = SquarePulse(
             length="#../x180_Square/length",
             amplitude="#../x90_Square/amplitude",
             digital_marker="#../x180_Square/digital_marker",
             axis_angle=np.pi / 2,
         )
-        nv_center.xy.operations["-y90_Square"] = pulses.SquarePulse(
+        nv_center.xy.operations["-y90_Square"] = SquarePulse(
             length="#../x180_Square/length",
             amplitude="#../x90_Square/amplitude",
             digital_marker="#../x180_Square/digital_marker",
@@ -72,31 +72,31 @@ def add_Square_pulses(
 
 def add_default_nv_center_pulses(nv_center: NVCenter):
     """Adds default pulses to a nv_center qubit:
-        * nv_center.xy.operations["cw"] = pulses.SquarePulse(amplitude=0.25, length=20 * u.us, axis_angle=0)
-        * nv_center.laser.operations["laser_on"] = pulses.SquarePulse(length=2000, amplitude=0.0, digital_marker="ON")
-        * nv_center.spcm.operations["readout"] = pulses.ReadoutPulse(length=400, digital_marker="ON")
+        * nv_center.xy.operations["cw"] = SquarePulse(amplitude=0.25, length=20 * u.us, axis_angle=0)
+        * nv_center.laser.operations["laser_on"] = Pulse(length=2000, amplitude=0.0, digital_marker="ON")
+        * nv_center.spcm.operations["readout"] = SquareReadoutPulse(length=400, digital_marker="ON")
 
     Args:
         nv_center (NVCenter): The nv_center qubit to which the pulses will be added.
     """
     if hasattr(nv_center, "xy"):
         if nv_center.xy is not None:
-            nv_center.xy.operations["cw"] = pulses.SquarePulse(
+            nv_center.xy.operations["cw"] = SquarePulse(
                 amplitude=0.25, length=20 * u.us, axis_angle=0
             )
 
     if hasattr(nv_center, "laser"):
         if nv_center.laser.trigger is not None:
-            nv_center.laser.trigger.operations["laser_on"] = pulses.Pulse(
+            nv_center.laser.trigger.operations["laser_on"] = Pulse(
                 length=3000 * u.ns, digital_marker="ON"
             )
-            nv_center.laser.trigger.operations["laser_off"] = pulses.Pulse(
+            nv_center.laser.trigger.operations["laser_off"] = Pulse(
                 length="#../laser_on/length", digital_marker=[[0, 0]]
             )
 
     if hasattr(nv_center, "spcm"):
         if nv_center.spcm is not None:
-            nv_center.spcm.operations["readout"] = pulses.SquareReadoutPulse(
+            nv_center.spcm.operations["readout"] = SquareReadoutPulse(
                 amplitude=0,
                 length=500 * u.ns,
                 digital_marker=None,
@@ -105,9 +105,9 @@ def add_default_nv_center_pulses(nv_center: NVCenter):
 
 def add_default_nv_center_pair_pulses(nv_center_pair: NVCenterPair):
     """Adds default pulses to a nv_center qubit pair depending on its attributes:
-        * nv_center_pair.coupler.operations["const"] = pulses.SquarePulse(amplitude=0.1, length=100)
-        * nv_center_pair.cross_resonance.operations["square"] = pulses.SquarePulse(amplitude=0.1, length=100)
-        * nv_center_pair.zz_drive.operations["square"] = pulses.SquarePulse(amplitude=0.1, length=100)
+        * nv_center_pair.coupler.operations["const"] = SquarePulse(amplitude=0.1, length=100)
+        * nv_center_pair.cross_resonance.operations["square"] = SquarePulse(amplitude=0.1, length=100)
+        * nv_center_pair.zz_drive.operations["square"] = SquarePulse(amplitude=0.1, length=100)
 
     Args:
         nv_center_pair (NVCenterPair): The nv_center qubit pair to which the pulses will be added.

--- a/quam_builder/builder/nv_center/build_quam.py
+++ b/quam_builder/builder/nv_center/build_quam.py
@@ -71,40 +71,40 @@ def _set_default_grid_location(qubit_number: int, total_number_of_qubits: int) -
     return f"{x},{y}"
 
 
-def add_nv_center(machine: AnyQuamNV):
-    """Adds NV center qubits and qubit pairs to the machine based on the wiring configuration.
+def _add_nv_line_components(
+    nv_center, element_type: str, qubit_id: str, wiring_by_line_type
+) -> None:
+    """Dispatches component creation for each line type of an NV center qubit."""
+    spcm_number = ""
+    for line_type, ports in wiring_by_line_type.items():
+        wiring_path = f"#/wiring/{element_type}/{qubit_id}/{line_type}"
+        if line_type == WiringLineType.LASER.value:
+            add_nv_laser_component(nv_center, wiring_path, ports)
+        elif line_type == WiringLineType.SPCM.value:
+            spcm_name = f"spcm{spcm_number}"
+            add_nv_spcm_component(nv_center, wiring_path, ports, spcm_name)
+            spcm_number = 1 if spcm_number == "" else spcm_number + 1
+        elif line_type == WiringLineType.DRIVE.value:
+            add_nv_drive_component(nv_center, wiring_path, ports)
+        else:
+            raise ValueError(f"Unknown line type: {line_type}")
 
-    Args:
-        machine (AnyQuamNV): The QuAM to which the NV center will be added.
-    """
+
+def add_nv_center(machine: AnyQuamNV):
     for element_type, wiring_by_element in machine.wiring.items():
         if element_type == "qubits":
             machine.active_qubit_names = []
-            number_of_qubits = len(wiring_by_element.items())
-            qubit_number = 0
-            for qubit_id, wiring_by_line_type in wiring_by_element.items():
+            number_of_qubits = len(wiring_by_element)
+            for qubit_number, (qubit_id, wiring_by_line_type) in enumerate(
+                wiring_by_element.items()
+            ):
                 qubit_class = machine.qubit_type
                 nv_center = qubit_class(id=qubit_id)
                 machine.qubits[qubit_id] = nv_center
                 machine.qubits[qubit_id].grid_location = _set_default_grid_location(
                     qubit_number, number_of_qubits
                 )
-                qubit_number += 1
-                spcm_number = ""
-                for line_type, ports in wiring_by_line_type.items():
-                    wiring_path = f"#/wiring/{element_type}/{qubit_id}/{line_type}"
-                    if line_type == WiringLineType.LASER.value:
-                        add_nv_laser_component(nv_center, wiring_path, ports)
-                    elif line_type == WiringLineType.SPCM.value:
-                        spcm_name = f"spcm{spcm_number}"
-                        add_nv_spcm_component(nv_center, wiring_path, ports, spcm_name)
-                        if spcm_number == "":
-                            spcm_number = 1
-                        spcm_number += 1
-                    elif line_type == WiringLineType.DRIVE.value:
-                        add_nv_drive_component(nv_center, wiring_path, ports)
-                    else:
-                        raise ValueError(f"Unknown line type: {line_type}")
+                _add_nv_line_components(nv_center, element_type, qubit_id, wiring_by_line_type)
                 machine.active_qubit_names.append(nv_center.name)
 
         elif element_type == "qubit_pairs":
@@ -177,9 +177,7 @@ def add_octaves(
             for line_type, references in wiring_by_line_type.items():
                 for reference in references:
                     if "octaves" in references.get_unreferenced_value(reference):
-                        octave_name = references.get_unreferenced_value(
-                            reference
-                        ).split("/")[2]
+                        octave_name = references.get_unreferenced_value(reference).split("/")[2]
                         octave = Octave(
                             name=octave_name,
                             calibration_db_path=str(calibration_db_path),
@@ -204,9 +202,7 @@ def add_external_mixers(machine: AnyQuamNV) -> AnyQuamNV:
             for line_type, references in wiring_by_line_type.items():
                 for reference in references:
                     if "mixers" in references.get_unreferenced_value(reference):
-                        mixer_name = references.get_unreferenced_value(reference).split(
-                            "/"
-                        )[2]
+                        mixer_name = references.get_unreferenced_value(reference).split("/")[2]
                         nv_center_channel = {
                             WiringLineType.DRIVE.value: "xy",
                             WiringLineType.RESONATOR.value: "resonator",

--- a/quam_builder/builder/nv_center/build_quam.py
+++ b/quam_builder/builder/nv_center/build_quam.py
@@ -10,7 +10,7 @@ from quam_builder.architecture.nv_center.qpu import AnyQuamNV
 from quam_builder.builder.nv_center.add_nv_laser_component import add_nv_laser_component
 from quam_builder.builder.nv_center.add_nv_spcm_component import add_nv_spcm_component
 from quam_builder.builder.nv_center.add_nv_drive_component import add_nv_drive_component
-from quam_builder.builder.nv_center.pulses import (
+from quam_builder.builder.nv_center.add_default_pulses import (
     add_default_nv_center_pulses,
     add_default_nv_center_pair_pulses,
 )

--- a/quam_builder/builder/quantum_dots/add_default_pulses.py
+++ b/quam_builder/builder/quantum_dots/add_default_pulses.py
@@ -9,7 +9,8 @@ Loss-DiVincenzo qubits, including:
 
 from typing import Any, Union
 import numpy as np
-from quam.components.pulses import GaussianPulse, SquareReadoutPulse, DragPulse
+from quam.components.pulses import SquareReadoutPulse, DragPulse
+from quam_builder.common.pulses import GaussianPulse
 from qualang_tools.addons.calibration.calibrations import unit
 from quam_builder.architecture.quantum_dots.qubit import LDQubit
 from quam_builder.architecture.quantum_dots.components import ReadoutResonatorBase

--- a/quam_builder/builder/quantum_dots/build_quam.py
+++ b/quam_builder/builder/quantum_dots/build_quam.py
@@ -23,7 +23,7 @@ from quam_builder.builder.quantum_dots.build_qpu import (
 from quam_builder.builder.quantum_dots.build_qpu_stage1 import _BaseQpuBuilder
 from quam_builder.builder.quantum_dots.build_qpu_stage2 import _LDQubitBuilder
 from quam_builder.architecture.quantum_dots.qpu import BaseQuamQD, LossDiVincenzoQuam
-from quam_builder.builder.quantum_dots.pulses import (
+from quam_builder.builder.quantum_dots.add_default_pulses import (
     add_default_ldv_qubit_pair_pulses,
     add_default_ldv_qubit_pulses,
     add_default_resonator_pulses,

--- a/quam_builder/builder/quantum_dots/build_utils.py
+++ b/quam_builder/builder/quantum_dots/build_utils.py
@@ -16,7 +16,8 @@ from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
 
 from numpy import ceil, sqrt
 from qualang_tools.wirer.connectivity.wiring_spec import WiringLineType
-from quam.components import StickyChannelAddon, pulses
+from quam.components import StickyChannelAddon
+from quam.components.pulses import SquareReadoutPulse
 from quam_builder.architecture.quantum_dots.components import (
     ReadoutResonatorSingle,
     VoltageGate,
@@ -188,7 +189,7 @@ def _make_resonator(sensor_id: str, wiring_path: str, resonator_cls: Any) -> Rea
         frequency_bare=0,
         intermediate_frequency=DEFAULT_INTERMEDIATE_FREQUENCY,
         operations={
-            "readout": pulses.SquareReadoutPulse(
+            "readout": SquareReadoutPulse(
                 length=DEFAULT_READOUT_LENGTH, id="readout", amplitude=DEFAULT_READOUT_AMPLITUDE
             )
         },

--- a/tests/quantum_dots/test_builder_pulses.py
+++ b/tests/quantum_dots/test_builder_pulses.py
@@ -9,7 +9,7 @@ from quam.components import StickyChannelAddon
 from quam.components.ports import LFFEMAnalogOutputPort, LFFEMAnalogInputPort
 
 from quam_builder.architecture.quantum_dots.components import ReadoutResonatorSingle, XYDriveSingle
-from quam_builder.builder.quantum_dots.pulses import (
+from quam_builder.builder.quantum_dots.add_default_pulses import (
     add_default_ldv_qubit_pulses,
     add_default_ldv_qubit_pair_pulses,
     add_default_resonator_pulses,


### PR DESCRIPTION
# Pull Request


## Description

Extends the pulse reorganization already done for superconducting (#112) to quantum dots and NV center, using the same conventions across architectures.

Builder helpers

Renamed `builder/quantum_dots/pulses.py` → `add_default_pulses.py`
Renamed` builder/nv_center/pulses.py` → `add_default_pulses.py`
Updated `build_quam.py` imports in both architectures

Pulse imports

Quantum dots: `GaussianPulse` now comes from `quam_builder.common.pulses`; `SquarePulse`, `SquareReadoutPulse,` and `Pulse` stay in `quam.components.pulses`
Quantum dots components: `xy_drive.py `and `gate_set.py` now use explicit class imports instead of from `quam.components import pulses`
Quantum dots builder: `build_utils.py` updated to import `SquareReadoutPulse` explicitly
NV center: switched to explicit imports of `Pulse`, `SquarePulse`, and `SquareReadoutPulse` from `quam.components.pulses`

Other

Updated `CHANGELOG.md` under [Unreleased]. Changes from #112 are also added now
Updated `tests/quantum_dots/test_builder_pulses.py ` import path
No new pulse classes are added in this PR; it aligns naming and imports with the superconducting refactor. quam, qua-libs, and downstream repos are unchanged.

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark relevant items with [x] -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [x] ✅ Test addition/update
- [ ] 🎨 Code style/formatting update

## Related Issues

<!-- Link related issues using keywords: Closes #123, Fixes #456, Relates to #789 -->

## Checklist

### Code Quality

- [ ] My code follows the project's style guidelines
- [ ] I have run `pre-commit` hooks and all checks pass (`pre-commit run --all-files`)
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have performed a self-review of my code
- [ ] My changes generate no new warnings

### Testing

- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally (`pytest`)
- [ ] I have tested my changes with the example scripts (if applicable)

### Documentation

- [ ] I have updated the documentation (if needed)
- [ ] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md (if applicable)
- [x] I have checked my code and corrected any misspellings

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include: -->
<!-- - What breaks -->
<!-- - Why the change was necessary -->
<!-- - Migration guide for users -->

**Does this PR introduce breaking changes?** <!-- Yes/No --> No
This PR only renames builder modules and updates internal imports within `quam-builder`. Public builder function names (`add_default_ldv_qubit_pulses`, `add_default_nv_center_pulses`, etc.) are unchanged.

Note for downstream users: Code that imported directly from the old module paths will need updating:
```
#Before
from quam_builder.builder.quantum_dots.pulses import add_default_ldv_qubit_pulses
from quam_builder.builder.nv_center.pulses import add_default_nv_center_pulses
# After
from quam_builder.builder.quantum_dots.add_default_pulses import add_default_ldv_qubit_pulses
from quam_builder.builder.nv_center.add_default_pulses import add_default_nv_center_pulses
```

QD examples under `architecture/quantum_dots/examples/ `still use from `quam.components` import pulses and are intentionally left unchanged for now.
## Testing Details

<!-- Describe how you tested your changes -->
<!-- Include: -->
<!-- - Test environment (Python version, OS, etc.) -->
<!-- - Steps to reproduce/verify -->
<!-- - Example code/scripts used for testing -->

## Screenshots/Examples

<!-- If applicable, add screenshots, code examples, or output samples -->

## Additional Context

<!-- Add any other context, implementation notes, or information about the PR here -->

## Reviewer Notes

<!-- Any specific areas you'd like reviewers to focus on? -->
