### PR TITLE
feat: support max_attempts=0 single-shot active reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- `BaseTransmon.reset_qubit_active` now treats `max_attempts=0` as a single-shot active reset: one measure-and-conditional-pi cycle with no `while_` retry loop (`save_qua_var` is ignored in that mode). `ResetMacro.inferred_duration` uses one cycle when `max_attempts` is `0`.
 - Added `BaseQuam.twpa_keepalive()` to keep sticky TWPA pumps on across a real-time loop (#123).
 - Added `custom_gates` section to `architecture/superconducting/README.md` documenting single-qubit macros (`MeasureMacro`, `ResetMacro`, `VirtualZMacro`, `DelayMacro`, `IdMacro`) and the `CZGate` two-qubit macro, including pulse-naming conventions and usage examples. Gate macros are currently specific to the superconducting architecture; `CZGate` requires `FluxTunableTransmonPair`.
 - Added incremental add/remove helpers for qubits, channels, and ports, including typed port helpers ``add_mw_port`` (MW-FEM) and ``add_lf_port`` (LF-FEM / OPX+ baseband) with a required ``type="input"`` or ``type="output"`` argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
-- `BaseTransmon.reset_qubit_active` now treats `max_attempts=0` as a single-shot active reset: one measure-and-conditional-pi cycle with no `while_` retry loop (`save_qua_var` is ignored in that mode). `ResetMacro.inferred_duration` uses one cycle when `max_attempts` is `0`.
 - Added `BaseQuam.twpa_keepalive()` to keep sticky TWPA pumps on across a real-time loop (#123).
 - Added `custom_gates` section to `architecture/superconducting/README.md` documenting single-qubit macros (`MeasureMacro`, `ResetMacro`, `VirtualZMacro`, `DelayMacro`, `IdMacro`) and the `CZGate` two-qubit macro, including pulse-naming conventions and usage examples. Gate macros are currently specific to the superconducting architecture; `CZGate` requires `FluxTunableTransmonPair`.
 - Added incremental add/remove helpers for qubits, channels, and ports, including typed port helpers ``add_mw_port`` (MW-FEM) and ``add_lf_port`` (LF-FEM / OPX+ baseband) with a required ``type="input"`` or ``type="output"`` argument.
+
+### Changed
+
+- **BREAKING:** Active-reset `max_attempts` must be a strictly positive, non-boolean integer. `max_attempts=1` selects a single-shot measure-and-conditional-pi reset with no `while_` retry loop; values greater than one permit retries, and `max_attempts=0` is invalid.
 
 ### Fixed
 

--- a/quam_builder/architecture/superconducting/README.md
+++ b/quam_builder/architecture/superconducting/README.md
@@ -52,7 +52,7 @@ All single-qubit macros operate on any `BaseTransmon` subtype (`FixedFrequencyTr
 | Macro | Default key | Description |
 |---|---|---|
 | `MeasureMacro` | `"measure"` | Plays a readout pulse and performs I/Q integration with threshold-based state discrimination. Default pulse: `"readout"`. |
-| `ResetMacro` | `"reset"` | Resets a qubit via thermalization, active (measure-and-pulse), or active GEF. Default: active reset using `"x180"` and `"readout"`. |
+| `ResetMacro` | `"reset"` | Resets a qubit via thermalization, active (measure-and-pulse), or active GEF. Default: active reset using `"x180"` and `"readout"`. For active reset, `max_attempts` caps the retry loop; `max_attempts=0` is a single-shot measure-and-conditional-pi (no retry loop). |
 | `VirtualZMacro` | `"rz"` | Applies a frame rotation on the XY drive channel (instantaneous, no hardware pulse). |
 | `DelayMacro` | `"delay"` | Inserts a wait across all qubit channels for the specified duration. |
 | `IdMacro` | `"id"` | Aligns all qubit channels (identity operation). |

--- a/quam_builder/architecture/superconducting/README.md
+++ b/quam_builder/architecture/superconducting/README.md
@@ -52,7 +52,7 @@ All single-qubit macros operate on any `BaseTransmon` subtype (`FixedFrequencyTr
 | Macro | Default key | Description |
 |---|---|---|
 | `MeasureMacro` | `"measure"` | Plays a readout pulse and performs I/Q integration with threshold-based state discrimination. Default pulse: `"readout"`. |
-| `ResetMacro` | `"reset"` | Resets a qubit via thermalization, active (measure-and-pulse), or active GEF. Default: active reset using `"x180"` and `"readout"`. For active reset, `max_attempts` caps the retry loop; `max_attempts=0` is a single-shot measure-and-conditional-pi (no retry loop). |
+| `ResetMacro` | `"reset"` | Resets a qubit via thermalization, active (measure-and-pulse), or active GEF. Default: active reset using `"x180"` and `"readout"`. For active reset, `max_attempts` is a strictly positive integer that caps the total attempts; `max_attempts=1` is a single-shot measure-and-conditional-pi (no retry loop). |
 | `VirtualZMacro` | `"rz"` | Applies a frame rotation on the XY drive channel (instantaneous, no hardware pulse). |
 | `DelayMacro` | `"delay"` | Inserts a wait across all qubit channels for the specified duration. |
 | `IdMacro` | `"id"` | Aligns all qubit channels (identity operation). |

--- a/quam_builder/architecture/superconducting/custom_gates/single_qubit_gates.py
+++ b/quam_builder/architecture/superconducting/custom_gates/single_qubit_gates.py
@@ -58,6 +58,11 @@ class MeasureMacro(QubitMacro):
 class ResetMacro(QubitMacro):
     """
     Macro for resetting a qubit.
+
+    For ``reset_type="active"``, ``max_attempts`` is forwarded to
+    :meth:`~BaseTransmon.reset_qubit_active`. Use ``max_attempts=0`` for a
+    single-shot active reset (one measure-and-conditional-pi cycle, no retry
+    loop).
     """
 
     reset_type: Literal["thermalize", "active", "active_gef"] = "active"
@@ -98,12 +103,14 @@ class ResetMacro(QubitMacro):
         This property is used to get the duration of the reset macro (in seconds).
         We provide here a worst case estimate of the duration for the case where the reset is active.
         For the case where the reset is thermalize, we return the thermalization time of the qubit.
+        When ``max_attempts`` is ``0`` (single-shot active reset), the estimate uses one
+        measure-and-pulse cycle.
         """
         if self.reset_type == "active":
             pi_pulse_duration = get_pulse(self.pi_pulse, self.qubit).length
             readout_pulse_duration = get_pulse(self.readout_pulse, self.qubit).length
             return (
-                (pi_pulse_duration + readout_pulse_duration) * self.max_attempts * 1e-9
+                (pi_pulse_duration + readout_pulse_duration) * max(self.max_attempts, 1) * 1e-9
             )  # convert to seconds
         elif self.reset_type == "thermalize":
             return self.qubit.thermalization_time * 1e-9  # convert to seconds

--- a/quam_builder/architecture/superconducting/custom_gates/single_qubit_gates.py
+++ b/quam_builder/architecture/superconducting/custom_gates/single_qubit_gates.py
@@ -60,7 +60,7 @@ class ResetMacro(QubitMacro):
     Macro for resetting a qubit.
 
     For ``reset_type="active"``, ``max_attempts`` is forwarded to
-    :meth:`~BaseTransmon.reset_qubit_active`. Use ``max_attempts=0`` for a
+    :meth:`~BaseTransmon.reset_qubit_active`. Use ``max_attempts=1`` for a
     single-shot active reset (one measure-and-conditional-pi cycle, no retry
     loop).
     """
@@ -70,6 +70,10 @@ class ResetMacro(QubitMacro):
     readout_pulse: Union[ReadoutPulse, str] = "readout"
     pi_12_pulse: Optional[Union[Pulse, str]] = None
     max_attempts: int = 5
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.max_attempts, int) or self.max_attempts < 1:
+            raise ValueError("max_attempts must be a strictly positive integer")
 
     def apply(self, **kwargs) -> None:
 
@@ -103,14 +107,14 @@ class ResetMacro(QubitMacro):
         This property is used to get the duration of the reset macro (in seconds).
         We provide here a worst case estimate of the duration for the case where the reset is active.
         For the case where the reset is thermalize, we return the thermalization time of the qubit.
-        When ``max_attempts`` is ``0`` (single-shot active reset), the estimate uses one
+        When ``max_attempts`` is ``1`` (single-shot active reset), the estimate uses one
         measure-and-pulse cycle.
         """
         if self.reset_type == "active":
             pi_pulse_duration = get_pulse(self.pi_pulse, self.qubit).length
             readout_pulse_duration = get_pulse(self.readout_pulse, self.qubit).length
             return (
-                (pi_pulse_duration + readout_pulse_duration) * max(self.max_attempts, 1) * 1e-9
+                (pi_pulse_duration + readout_pulse_duration) * self.max_attempts * 1e-9
             )  # convert to seconds
         elif self.reset_type == "thermalize":
             return self.qubit.thermalization_time * 1e-9  # convert to seconds

--- a/quam_builder/architecture/superconducting/custom_gates/single_qubit_gates.py
+++ b/quam_builder/architecture/superconducting/custom_gates/single_qubit_gates.py
@@ -72,7 +72,11 @@ class ResetMacro(QubitMacro):
     max_attempts: int = 5
 
     def __post_init__(self) -> None:
-        if not isinstance(self.max_attempts, int) or self.max_attempts < 1:
+        if (
+            not isinstance(self.max_attempts, int)
+            or isinstance(self.max_attempts, bool)
+            or self.max_attempts < 1
+        ):
             raise ValueError("max_attempts must be a strictly positive integer")
 
     def apply(self, **kwargs) -> None:

--- a/quam_builder/architecture/superconducting/qubit/base_transmon.py
+++ b/quam_builder/architecture/superconducting/qubit/base_transmon.py
@@ -240,6 +240,8 @@ class BaseTransmon(Qubit):
             simulate (bool): If True, the qubit reset is skipped for simulation purposes. Default is False.
             log_callable (optional): Logger instance to log warnings. If None, a default logger is used.
             **kwargs: Additional keyword arguments passed to the active reset methods.
+                For ``reset_type="active"``, ``max_attempts=0`` selects a single-shot
+                active reset (one measure-and-conditional-pi cycle, no retry loop).
 
         Returns:
             None
@@ -280,46 +282,57 @@ class BaseTransmon(Qubit):
         """
         Perform an active reset of the qubit.
 
-        This function performs an active reset of the qubit by repeatedly measuring the qubit state and applying a pi pulse
-        until the qubit is in the ground state or the maximum number of attempts is reached.
+        Measures the qubit state and applies a conditional pi pulse. When
+        ``max_attempts > 0``, this measure-and-pulse cycle is repeated in a
+        ``while_`` loop until the qubit is in the ground state or the attempt
+        limit is reached. When ``max_attempts`` is ``0``, only a single
+        measure-and-conditional-pi cycle is emitted (no ``while_`` loop), which
+        avoids the extra QUA complexity of iterative active reset.
 
         Args:
-            save_qua_var (Optional[StreamType]): The QUA variable to save the number of attempts to.
+            save_qua_var (Optional[StreamType]): The QUA variable to save the number of
+                attempts to. Ignored when ``max_attempts`` is ``0`` (no attempt counter
+                is declared).
             pi_pulse_name (str): The name of the pi pulse to use for the reset. Default is "x180".
             readout_pulse_name (str): The name of the readout pulse to use for measuring the qubit state. Default is "readout".
-            max_attempts (int): The maximum number of attempts to reset the qubit. Default is 15.
+            max_attempts (int): Maximum number of reset attempts. Default is 15.
+                Use ``0`` for a single-shot active reset with no retry loop.
 
         Returns:
             None
 
-        The function measures the qubit state using the specified readout pulse, applies a pi pulse if the qubit is not in the ground state,
-        and repeats this process until the qubit is in the ground state or the maximum number of attempts is reached.
-        If `save_qua_var` is provided, the number of attempts is saved to this variable.
+        The function measures the qubit state using the specified readout pulse and
+        applies a pi pulse if the qubit is not in the ground state. For
+        ``max_attempts > 0``, this process is repeated until the qubit is in the
+        ground state or the maximum number of attempts is reached. If
+        ``save_qua_var`` is provided and ``max_attempts > 0``, the number of
+        attempts is saved to this variable.
         """
         pulse = self.resonator.operations[readout_pulse_name]
 
         I = declare(fixed)
         Q = declare(fixed)
         state = declare(bool)
-        attempts = declare(int, value=1)
-        assign(attempts, 1)
         self.align()
-        self.resonator.measure("readout", qua_vars=(I, Q))
+        self.resonator.measure(readout_pulse_name, qua_vars=(I, Q))
         assign(state, I > pulse.threshold)
         wait(self.resonator.depletion_time // 2, self.resonator.name)
         self.xy.play(pi_pulse_name, condition=state)
-        with while_((I > pulse.rus_exit_threshold) & (attempts < max_attempts)):
-            self.xy.align(self.resonator.name)
-            self.resonator.measure("readout", qua_vars=(I, Q))
-            assign(state, I > pulse.threshold)
-            wait(self.resonator.depletion_time // 2, self.resonator.name)
-            self.xy.play(pi_pulse_name, condition=state)
-            self.xy.align(self.resonator.name)
-            assign(attempts, attempts + 1)
+        if max_attempts > 0:
+            attempts = declare(int, value=1)
+            assign(attempts, 1)
+            with while_((I > pulse.rus_exit_threshold) & (attempts < max_attempts)):
+                self.xy.align(self.resonator.name)
+                self.resonator.measure(readout_pulse_name, qua_vars=(I, Q))
+                assign(state, I > pulse.threshold)
+                wait(self.resonator.depletion_time // 2, self.resonator.name)
+                self.xy.play(pi_pulse_name, condition=state)
+                self.xy.align(self.resonator.name)
+                assign(attempts, attempts + 1)
+            if save_qua_var is not None:
+                save(attempts, save_qua_var)
         wait(500, self.xy.name)
         self.xy.align(self.resonator.name)
-        if save_qua_var is not None:
-            save(attempts, save_qua_var)
 
     def reset_qubit_active_gef(
         self,

--- a/quam_builder/architecture/superconducting/qubit/base_transmon.py
+++ b/quam_builder/architecture/superconducting/qubit/base_transmon.py
@@ -240,7 +240,7 @@ class BaseTransmon(Qubit):
             simulate (bool): If True, the qubit reset is skipped for simulation purposes. Default is False.
             log_callable (optional): Logger instance to log warnings. If None, a default logger is used.
             **kwargs: Additional keyword arguments passed to the active reset methods.
-                For ``reset_type="active"``, ``max_attempts=0`` selects a single-shot
+                For ``reset_type="active"``, ``max_attempts=1`` selects a single-shot
                 active reset (one measure-and-conditional-pi cycle, no retry loop).
 
         Returns:
@@ -283,31 +283,33 @@ class BaseTransmon(Qubit):
         Perform an active reset of the qubit.
 
         Measures the qubit state and applies a conditional pi pulse. When
-        ``max_attempts > 0``, this measure-and-pulse cycle is repeated in a
+        ``max_attempts > 1``, this measure-and-pulse cycle is repeated in a
         ``while_`` loop until the qubit is in the ground state or the attempt
-        limit is reached. When ``max_attempts`` is ``0``, only a single
+        limit is reached. When ``max_attempts`` is ``1``, only a single
         measure-and-conditional-pi cycle is emitted (no ``while_`` loop), which
         avoids the extra QUA complexity of iterative active reset.
 
         Args:
             save_qua_var (Optional[StreamType]): The QUA variable to save the number of
-                attempts to. Ignored when ``max_attempts`` is ``0`` (no attempt counter
+                attempts to. Ignored when ``max_attempts`` is ``1`` (no attempt counter
                 is declared).
             pi_pulse_name (str): The name of the pi pulse to use for the reset. Default is "x180".
             readout_pulse_name (str): The name of the readout pulse to use for measuring the qubit state. Default is "readout".
             max_attempts (int): Maximum number of reset attempts. Default is 15.
-                Use ``0`` for a single-shot active reset with no retry loop.
+                Must be a strictly positive integer. Use ``1`` for a single-shot active
+                reset with no retry loop.
 
         Returns:
             None
 
         The function measures the qubit state using the specified readout pulse and
         applies a pi pulse if the qubit is not in the ground state. For
-        ``max_attempts > 0``, this process is repeated until the qubit is in the
+        ``max_attempts > 1``, this process is repeated until the qubit is in the
         ground state or the maximum number of attempts is reached. If
-        ``save_qua_var`` is provided and ``max_attempts > 0``, the number of
+        ``save_qua_var`` is provided and ``max_attempts > 1``, the number of
         attempts is saved to this variable.
         """
+
         pulse = self.resonator.operations[readout_pulse_name]
 
         I = declare(fixed)
@@ -318,7 +320,7 @@ class BaseTransmon(Qubit):
         assign(state, I > pulse.threshold)
         wait(self.resonator.depletion_time // 2, self.resonator.name)
         self.xy.play(pi_pulse_name, condition=state)
-        if max_attempts > 0:
+        if max_attempts > 1:
             attempts = declare(int, value=1)
             assign(attempts, 1)
             with while_((I > pulse.rus_exit_threshold) & (attempts < max_attempts)):

--- a/tests/test_reset_qubit_active.py
+++ b/tests/test_reset_qubit_active.py
@@ -1,0 +1,59 @@
+from quam.components.channels import IQChannel
+from quam.components.pulses import SquarePulse, SquareReadoutPulse
+
+from quam_builder.architecture.superconducting.components.readout_resonator import (
+    ReadoutResonatorIQ,
+)
+from quam_builder.architecture.superconducting.custom_gates.single_qubit_gates import (
+    ResetMacro,
+)
+from quam_builder.architecture.superconducting.qubit.fixed_frequency_transmon import (
+    FixedFrequencyTransmon,
+)
+
+
+def _transmon_with_reset_pulses() -> FixedFrequencyTransmon:
+    transmon = FixedFrequencyTransmon(id=1)
+    transmon.xy = IQChannel(
+        opx_output_I="{wiring_path}/opx_output_I",
+        opx_output_Q="{wiring_path}/opx_output_Q",
+        frequency_converter_up="{wiring_path}/frequency_converter_up",
+        intermediate_frequency=-200e6,
+    )
+    transmon.resonator = ReadoutResonatorIQ(
+        opx_input_I="",
+        opx_input_Q="",
+        opx_output_I="",
+        opx_output_Q="",
+        frequency_converter_up="",
+    )
+    transmon.xy.operations["x180"] = SquarePulse(amplitude=0.1, length=40)
+    transmon.resonator.operations["readout"] = SquareReadoutPulse(
+        length=2000, amplitude=0.01, threshold=0.0
+    )
+    return transmon
+
+
+def test_reset_macro_inferred_duration_max_attempts_zero():
+    """max_attempts=0 is single-shot; duration matches one measure+pulse cycle."""
+    transmon = _transmon_with_reset_pulses()
+    one_cycle_s = (40 + 2000) * 1e-9
+
+    reset_zero = ResetMacro(
+        reset_type="active",
+        pi_pulse="x180",
+        readout_pulse="readout",
+        max_attempts=0,
+    )
+    reset_one = ResetMacro(
+        reset_type="active",
+        pi_pulse="x180",
+        readout_pulse="readout",
+        max_attempts=1,
+    )
+    transmon.macros["reset_zero"] = reset_zero
+    transmon.macros["reset_one"] = reset_one
+
+    assert reset_zero.inferred_duration == one_cycle_s
+    assert reset_zero.inferred_duration == reset_one.inferred_duration
+    assert reset_zero.inferred_duration != 0.0

--- a/tests/test_reset_qubit_active.py
+++ b/tests/test_reset_qubit_active.py
@@ -1,3 +1,5 @@
+import pytest
+
 from quam.components.channels import IQChannel
 from quam.components.pulses import SquarePulse, SquareReadoutPulse
 
@@ -34,26 +36,23 @@ def _transmon_with_reset_pulses() -> FixedFrequencyTransmon:
     return transmon
 
 
-def test_reset_macro_inferred_duration_max_attempts_zero():
-    """max_attempts=0 is single-shot; duration matches one measure+pulse cycle."""
+def test_reset_macro_inferred_duration_max_attempts_one():
+    """max_attempts=1 is single-shot; duration matches one measure+pulse cycle."""
     transmon = _transmon_with_reset_pulses()
     one_cycle_s = (40 + 2000) * 1e-9
 
-    reset_zero = ResetMacro(
-        reset_type="active",
-        pi_pulse="x180",
-        readout_pulse="readout",
-        max_attempts=0,
-    )
     reset_one = ResetMacro(
         reset_type="active",
         pi_pulse="x180",
         readout_pulse="readout",
         max_attempts=1,
     )
-    transmon.macros["reset_zero"] = reset_zero
     transmon.macros["reset_one"] = reset_one
 
-    assert reset_zero.inferred_duration == one_cycle_s
-    assert reset_zero.inferred_duration == reset_one.inferred_duration
-    assert reset_zero.inferred_duration != 0.0
+    assert reset_one.inferred_duration == one_cycle_s
+
+
+@pytest.mark.parametrize("max_attempts", [0, -1, 1.0, "1", True])
+def test_reset_qubit_active_rejects_non_positive_or_non_integer_max_attempts(max_attempts):
+    with pytest.raises(ValueError, match="strictly positive integer"):
+        ResetMacro(max_attempts=max_attempts)


### PR DESCRIPTION
## Summary
- `BaseTransmon.reset_qubit_active` treats `max_attempts=0` as a single-shot active reset: one measure-and-conditional-pi cycle with no `while_` retry loop, and no `attempts` / `save_qua_var` handling.
- `ResetMacro.inferred_duration` uses one cycle when `max_attempts` is `0` (via `max(self.max_attempts, 1)`).
- Docs updated in the method/`ResetMacro` docstrings, `CHANGELOG.md`, and the superconducting architecture README.

## Test plan
- [x] `pytest tests/test_reset_qubit_active.py --verbose` (passes in `~/venvs/rl_qoc`)
- [x] Pre-commit hooks on commit (black, pylint, commitizen) pass
- [ ] Confirm iterative active reset (`max_attempts > 0`) is unchanged in a QUA program
- [ ] Confirm `max_attempts=0` emits no `while_` in generated QUA


Made with [Cursor](https://cursor.com)