### PR TITLE
feat(pulses): add DrachmaReadoutPulse readout scheme

### DIFF
--- a/quam_builder/common/pulses.py
+++ b/quam_builder/common/pulses.py
@@ -8,6 +8,7 @@ __all__ = [
     "FlatTopGaussianPulse",
     "FlatTopCosinePulse",
     "GaussianFilteredSquarePulse",
+    "DrachmaReadoutPulse",
 ]
 
 
@@ -255,16 +256,21 @@ class DrachmaReadoutPulse(ReadoutPulse):
     ground- and excited-state resonator frequencies (detuning_{0,1} = +-chi
     in the paper's notation, where chi is the dispersive shift).
 
-    Sampling convention: one waveform sample = 1 ns, so resonator_kappa_hz
-    and detuning_*_hz are given in Hz and converted internally (via a
-    factor of 1e-9) to the per-sample units used by kappa/2pi, chi/2pi in
-    the paper (e.g. kappa/2pi = 0.5647 MHz -> resonator_kappa_hz = 564700).
+    resonator_kappa_hz and detuning_*_hz are given in Hz and converted
+    internally (via a factor of 1/sample_rate) to the per-sample units used
+    by kappa/2pi, chi/2pi in the paper (e.g. for sample_rate = 1e9 Sa/s,
+    kappa/2pi = 0.5647 MHz -> resonator_kappa_hz = 564700).
+
+    Args:
+        sample_rate (float): Sample rate in Hz used to convert resonator_kappa_hz
+            and detuning_*_hz to per-sample units (default 1e9, i.e. 1 sample = 1 ns).
     """
 
     amplitude: float  # NOT a peak amplitude, determines the area under the graph similar to square pulse amplitude
     resonator_kappa_hz: float  # kappa/(2*pi), Hz
     detuning_ground_hz: float  # detuning of ground state relative to carrier, Hz
     detuning_excited_hz: float  # detuning of excited state relative to carrier, Hz
+    sample_rate: float = 1e9
 
     def _trial_function(self):
         """sin^3(pi t / Tp), sampled so BOTH endpoints are exactly zero.
@@ -278,10 +284,10 @@ class DrachmaReadoutPulse(ReadoutPulse):
         """Coefficients of the polynomial in D = d/dt for
         prod_j (kappa/2 + i*detuning_j + D). coeffs[k] multiplies the k-th
         time derivative of a_T(t)."""
-        kappa = 2 * np.pi * self.resonator_kappa_hz * 1e-9
+        kappa = 2 * np.pi * self.resonator_kappa_hz / self.sample_rate
         detunings = [
-            2 * np.pi * self.detuning_ground_hz * 1e-9,
-            2 * np.pi * self.detuning_excited_hz * 1e-9,
+            2 * np.pi * self.detuning_ground_hz / self.sample_rate,
+            2 * np.pi * self.detuning_excited_hz / self.sample_rate,
         ]
 
         coeffs = np.array([1.0 + 0.0j])
@@ -303,8 +309,23 @@ class DrachmaReadoutPulse(ReadoutPulse):
     def waveform_function(self):
         """Constructs a_in(t) per Eq. (7), applied as a direct time-domain
         differential operator on a_T(t) = sin^3(pi t / Tp)."""
+        if self.length < 2:
+            raise ValueError(
+                "DrachmaReadoutPulse.length must be at least 2 samples "
+                f"(got {self.length}); the trial function is undefined for length == 1."
+            )
+        if self.resonator_kappa_hz <= 0:
+            raise ValueError(
+                "DrachmaReadoutPulse.resonator_kappa_hz must be positive "
+                f"(got {self.resonator_kappa_hz})"
+            )
+        if self.sample_rate <= 0:
+            raise ValueError(
+                f"DrachmaReadoutPulse.sample_rate must be positive (got {self.sample_rate})"
+            )
+
         norm = self.amplitude * self.length
-        kappa = 2 * np.pi * self.resonator_kappa_hz * 1e-9
+        kappa = 2 * np.pi * self.resonator_kappa_hz / self.sample_rate
         a_T = self._trial_function()
         coeffs, n_states = self._differential_operator_coeffs()
 
@@ -315,6 +336,12 @@ class DrachmaReadoutPulse(ReadoutPulse):
             a_in += c_k * derivatives[k]
         a_in /= kappa ** (n_states / 2)
 
-        a_in = norm * a_in / np.sum(np.abs(a_in))  # normalize to desired amplitude
+        a_in_sum = np.sum(np.abs(a_in))
+        if a_in_sum == 0:
+            raise ValueError(
+                "DrachmaReadoutPulse waveform_function produced an all-zero waveform "
+                "before normalization; cannot normalize to the requested amplitude."
+            )
+        a_in = norm * a_in / a_in_sum  # normalize to desired amplitude
 
         return a_in

--- a/quam_builder/common/pulses.py
+++ b/quam_builder/common/pulses.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from quam.core import quam_dataclass
-from quam.components.pulses import Pulse
+from quam.components.pulses import Pulse, ReadoutPulse
 
 __all__ = [
     "GaussianPulse",
@@ -232,3 +232,89 @@ class GaussianFilteredSquarePulse(Pulse):
         if self.axis_angle is not None:
             env = env * np.exp(1j * self.axis_angle)
         return env
+
+
+@quam_dataclass
+class DrachmaReadoutPulse(ReadoutPulse):
+    """DRACHMA readout scheme, as described in Jerger et al.,
+    "Dispersive Qubit Readout with Intrinsic Resonator Reset" (arXiv:2406.04891).
+
+    The pulse is built from the analytic trial function a_T(t) = sin^3(pi t / Tp)
+    and inverted through the state-dependent resonator response, following
+    Eqs. (6)-(7) of the paper:
+
+        a_in(t) = [ prod_j (kappa/2 + i*chi_j + d/dt) ] a_T(t) / kappa^(N/2)
+
+    where chi_j are the dispersive shifts of each computational state relative
+    to the drive carrier and kappa is the resonator linewidth. For N=2 states
+    this is just a second-order differential operator acting on a_T(t), so we
+    apply it directly in the time domain -- no FFT/deconvolution required.
+
+    IMPORTANT: detuning_ground_hz / detuning_excited_hz are defined relative
+    to the drive carrier, which the paper places halfway between the
+    ground- and excited-state resonator frequencies (detuning_{0,1} = +-chi
+    in the paper's notation, where chi is the dispersive shift).
+
+    Sampling convention: one waveform sample = 1 ns, so resonator_kappa_hz
+    and detuning_*_hz are given in Hz and converted internally (via a
+    factor of 1e-9) to the per-sample units used by kappa/2pi, chi/2pi in
+    the paper (e.g. kappa/2pi = 0.5647 MHz -> resonator_kappa_hz = 564700).
+    """
+
+    amplitude_integral_v_ns: float
+    resonator_kappa_hz: float  # kappa/(2*pi), Hz
+    detuning_ground_hz: float  # detuning of ground state relative to carrier, Hz
+    detuning_excited_hz: float  # detuning of excited state relative to carrier, Hz
+
+    def _trial_function(self):
+        """sin^3(pi t / Tp), sampled so BOTH endpoints are exactly zero.
+        (Needed because the smoothness condition requires a_T and its first
+        N-1 derivatives to vanish at t=0 and t=Tp; np.arange(length)/length
+        never actually reaches the second boundary.)"""
+        theta = np.pi * np.arange(self.length) / (self.length - 1)
+        return np.sin(theta) ** 3
+
+    def _differential_operator_coeffs(self):
+        """Coefficients of the polynomial in D = d/dt for
+        prod_j (kappa/2 + i*detuning_j + D). coeffs[k] multiplies the k-th
+        time derivative of a_T(t)."""
+        kappa = 2 * np.pi * self.resonator_kappa_hz * 1e-9
+        detunings = [
+            2 * np.pi * self.detuning_ground_hz * 1e-9,
+            2 * np.pi * self.detuning_excited_hz * 1e-9,
+        ]
+
+        coeffs = np.array([1.0 + 0.0j])
+        for detuning in detunings:
+            factor = np.array([kappa / 2 + 1j * detuning, 1.0 + 0.0j])  # [D^0, D^1]
+            coeffs = np.convolve(coeffs, factor)
+        return coeffs, len(detunings)
+
+    def _time_derivatives(self, signal, max_order, dt=1.0):
+        """[signal, d(signal)/dt, d^2(signal)/dt^2, ...] via centered finite
+        differences, one sample = dt (ns)."""
+        derivatives = [signal]
+        current = signal
+        for _ in range(max_order):
+            current = np.gradient(current, dt)
+            derivatives.append(current)
+        return derivatives
+
+    def waveform_function(self):
+        """Constructs a_in(t) per Eq. (7), applied as a direct time-domain
+        differential operator on a_T(t) = sin^3(pi t / Tp)."""
+        norm = self.amplitude_integral_v_ns
+        kappa = 2 * np.pi * self.resonator_kappa_hz * 1e-9
+        a_T = self._trial_function()
+        coeffs, n_states = self._differential_operator_coeffs()
+
+        derivatives = self._time_derivatives(a_T, max_order=len(coeffs) - 1)
+
+        a_in = np.zeros_like(a_T, dtype=complex)
+        for k, c_k in enumerate(coeffs):
+            a_in += c_k * derivatives[k]
+        a_in /= kappa ** (n_states / 2)
+
+        a_in = norm * a_in / np.sum(np.abs(a_in))  # normalize to desired amplitude
+
+        return a_in

--- a/quam_builder/common/pulses.py
+++ b/quam_builder/common/pulses.py
@@ -261,7 +261,7 @@ class DrachmaReadoutPulse(ReadoutPulse):
     the paper (e.g. kappa/2pi = 0.5647 MHz -> resonator_kappa_hz = 564700).
     """
 
-    amplitude_integral_v_ns: float
+    amplitude: float  # NOT a peak amplitude, determines the area under the graph similar to square pulse amplitude
     resonator_kappa_hz: float  # kappa/(2*pi), Hz
     detuning_ground_hz: float  # detuning of ground state relative to carrier, Hz
     detuning_excited_hz: float  # detuning of excited state relative to carrier, Hz
@@ -303,7 +303,7 @@ class DrachmaReadoutPulse(ReadoutPulse):
     def waveform_function(self):
         """Constructs a_in(t) per Eq. (7), applied as a direct time-domain
         differential operator on a_T(t) = sin^3(pi t / Tp)."""
-        norm = self.amplitude_integral_v_ns
+        norm = self.amplitude * self.length
         kappa = 2 * np.pi * self.resonator_kappa_hz * 1e-9
         a_T = self._trial_function()
         coeffs, n_states = self._differential_operator_coeffs()

--- a/tests/test_common_pulses.py
+++ b/tests/test_common_pulses.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+from quam_builder.common.pulses import DrachmaReadoutPulse
+
+
+def _make_pulse(**overrides):
+    kwargs = dict(
+        length=100,
+        amplitude_integral_v_ns=0.5,
+        resonator_kappa_hz=564700.0,
+        detuning_ground_hz=299000.0,
+        detuning_excited_hz=-299000.0,
+    )
+    kwargs.update(overrides)
+    return DrachmaReadoutPulse(**kwargs)
+
+
+def test_required_fields_have_no_defaults():
+    with pytest.raises(TypeError):
+        DrachmaReadoutPulse(length=100)
+
+
+def test_waveform_shape_and_dtype():
+    pulse = _make_pulse()
+    waveform = pulse.waveform_function()
+    assert waveform.shape == (100,)
+    assert np.iscomplexobj(waveform)
+
+
+def test_waveform_amplitude_normalization():
+    pulse = _make_pulse(amplitude_integral_v_ns=0.5)
+    waveform = pulse.waveform_function()
+    assert np.sum(np.abs(waveform)) == pytest.approx(0.5)
+
+
+def test_waveform_depends_on_detuning():
+    waveform_a = _make_pulse(
+        detuning_ground_hz=299000.0, detuning_excited_hz=-299000.0
+    ).waveform_function()
+    waveform_b = _make_pulse(
+        detuning_ground_hz=100000.0, detuning_excited_hz=-100000.0
+    ).waveform_function()
+    assert not np.allclose(waveform_a, waveform_b)
+
+
+def test_zero_detuning_yields_real_waveform():
+    pulse = _make_pulse(detuning_ground_hz=0.0, detuning_excited_hz=0.0)
+    waveform = pulse.waveform_function()
+    assert np.allclose(waveform.imag, 0, atol=1e-9)

--- a/tests/test_common_pulses.py
+++ b/tests/test_common_pulses.py
@@ -7,7 +7,7 @@ from quam_builder.common.pulses import DrachmaReadoutPulse
 def _make_pulse(**overrides):
     kwargs = dict(
         length=100,
-        amplitude_integral_v_ns=0.5,
+        amplitude=0.5,
         resonator_kappa_hz=564700.0,
         detuning_ground_hz=299000.0,
         detuning_excited_hz=-299000.0,
@@ -29,9 +29,11 @@ def test_waveform_shape_and_dtype():
 
 
 def test_waveform_amplitude_normalization():
-    pulse = _make_pulse(amplitude_integral_v_ns=0.5)
+    pulse = _make_pulse(amplitude=0.5, length=100)
     waveform = pulse.waveform_function()
-    assert np.sum(np.abs(waveform)) == pytest.approx(0.5)
+    # amplitude * length mirrors SquarePulse's convention: the area under the
+    # waveform equals amplitude * length, not amplitude alone.
+    assert np.sum(np.abs(waveform)) == pytest.approx(0.5 * 100)
 
 
 def test_waveform_depends_on_detuning():
@@ -48,3 +50,21 @@ def test_zero_detuning_yields_real_waveform():
     pulse = _make_pulse(detuning_ground_hz=0.0, detuning_excited_hz=0.0)
     waveform = pulse.waveform_function()
     assert np.allclose(waveform.imag, 0, atol=1e-9)
+
+
+def test_length_one_raises():
+    pulse = _make_pulse(length=1)
+    with pytest.raises(ValueError):
+        pulse.waveform_function()
+
+
+def test_zero_kappa_raises():
+    pulse = _make_pulse(resonator_kappa_hz=0.0)
+    with pytest.raises(ValueError):
+        pulse.waveform_function()
+
+
+def test_sample_rate_rescales_waveform():
+    waveform_1ghz = _make_pulse(sample_rate=1e9).waveform_function()
+    waveform_2ghz = _make_pulse(sample_rate=2e9).waveform_function()
+    assert not np.allclose(waveform_1ghz, waveform_2ghz)


### PR DESCRIPTION
## Summary

Adds `DrachmaReadoutPulse` to `quam_builder.common.pulses`: a readout pulse
implementing the DRACHMA scheme from Jerger et al., *"Dispersive Qubit
Readout with Intrinsic Resonator Reset"* (arXiv:2406.04891).

The waveform is built from the analytic trial function
`a_T(t) = sin^3(pi t / Tp)` and inverted through the state-dependent
resonator response (Eqs. 6-7 of the paper) as a direct time-domain
differential operator — no FFT/deconvolution required.

## Impact on existing QUAM configurations

None. This is a new, additive `Pulse` subclass in `quam_builder/common/pulses.py`.
No existing components, classes, or configs are modified.

## Usage example

```python
from quam_builder.common.pulses import DrachmaReadoutPulse

pulse = DrachmaReadoutPulse(
    length=100,                      # samples
    amplitude=0.005,                 # V; area under the waveform = amplitude * length (V*ns)
    resonator_kappa_hz=564_700.0,    # kappa / (2*pi), Hz
    detuning_ground_hz=299_000.0,    # ground-state detuning from drive carrier, Hz
    detuning_excited_hz=-299_000.0,  # excited-state detuning from drive carrier, Hz
    sample_rate=1e9,                 # Sa/s, default 1e9 (1 sample = 1 ns)
)
resonator.operations["readout_drachma"] = pulse
```

## Testing

Validated against a real experiment. Automated pytest coverage for this
class is added in a follow-up commit on this branch/PR
(`tests/test_common_pulses.py`), covering waveform shape/dtype, amplitude
normalization, detuning dependence, and the length/kappa divide-by-zero
guards.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
