### PR TITLE
Fix/restore anyquamqd alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - Fixed TWPA pump initialization being skipped in subsequent QUA programs due to process-global deduplication state ([#122](https://github.com/qua-platform/quam-builder/issues/122)).
+- Restored `AnyQuamQD` type alias (`Union[BaseQuamQD, LossDiVincenzoQuam]`) in `architecture.quantum_dots.qpu`, fixing imports used by `qualibration-libs`.
 - `add_default_transmon_pair_macros` now passes `flux_pulse_qubit="const"` (was `flux_pulse_control="const"`) to `CZGate`, matching the field rename introduced in v0.4.0 and aligning with the `"const"` pulse added to every `FluxTunableTransmon` Z line by `add_default_transmon_pulses`.
 - Applied black formatting across the entire repo.
 

--- a/quam_builder/architecture/quantum_dots/qpu/__init__.py
+++ b/quam_builder/architecture/quantum_dots/qpu/__init__.py
@@ -2,8 +2,11 @@ from . import base_quam_qd
 from .base_quam_qd import *
 from . import loss_divincenzo_quam
 from .loss_divincenzo_quam import *
+from typing import Union
 
 __all__ = [
     *base_quam_qd.__all__,
     *loss_divincenzo_quam.__all__,
 ]
+
+AnyQuamQD = Union[BaseQuamQD, LossDiVincenzoQuam]


### PR DESCRIPTION
## Description

- Re-export AnyQuamQD = Union[BaseQuamQD, LossDiVincenzoQuam] from quantum_dots.qpu
- Aligns with AnyQuam / AnyQuamNV and fixes qualibration-libs imports

- Needed by qualibration-libs: qualibration_libs/parameters/experiment.py imports AnyQuamQD and uses it in get_qubits() / get_qubit_pairs() signatures (Union[AnyQuam, AnyQuamQD]) so nodes work for both superconducting and quantum-dot QUAM machines
- Without this alias, qualibration-libs tests fail at import (tests/test_experiment.py)

## Type of Change

<!-- Mark relevant items with [x] -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ✅ Test addition/update
- [ ] 🎨 Code style/formatting update

### Code Quality

- [x ] My code follows the project's style guidelines
- [x] I have run `pre-commit` hooks and all checks pass (`pre-commit run --all-files`)
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have performed a self-review of my code
- [ ] My changes generate no new warnings

### Testing

- [x] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass locally (`pytest`)
- [ ] I have tested my changes with the example scripts (if applicable)