### PR TITLE
Bump version 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-19
+
 ### Added
 
 - Added `BaseQuam.twpa_keepalive()` to keep sticky TWPA pumps on across a real-time loop (#123).
-- Added `custom_gates` section to `architecture/superconducting/README.md` documenting single-qubit macros (`MeasureMacro`, `ResetMacro`, `VirtualZMacro`, `DelayMacro`, `IdMacro`) and the `CZGate` two-qubit macro, including pulse-naming conventions and usage examples. Gate macros are currently specific to the superconducting architecture; `CZGate` requires `FluxTunableTransmonPair`.
-- Added incremental add/remove helpers for qubits, channels, and ports, including typed port helpers ``add_mw_port`` (MW-FEM) and ``add_lf_port`` (LF-FEM / OPX+ baseband) with a required ``type="input"`` or ``type="output"`` argument.
+- Added default single-qubit gate macros for transmons (`MeasureMacro`, `ResetMacro`, `VirtualZMacro`, `DelayMacro`, `IdMacro`) (#101).
+- Added `DrachmaReadoutPulse` readout scheme (#140).
+- Added `custom_gates` section to `architecture/superconducting/README.md` documenting single-qubit macros and the `CZGate` two-qubit macro, including pulse-naming conventions and usage examples. Gate macros are currently specific to the superconducting architecture; `CZGate` requires `FluxTunableTransmonPair`.
+- Added incremental add/remove helpers for qubits, channels, and ports, including typed port helpers ``add_mw_port`` (MW-FEM) and ``add_lf_port`` (LF-FEM / OPX+ baseband) with a required ``type="input"`` or ``type="output"`` argument (#121).
 
 ### Changed
 
-- **BREAKING:** Active-reset `max_attempts` must be a strictly positive, non-boolean integer. `max_attempts=1` selects a single-shot measure-and-conditional-pi reset with no `while_` retry loop; values greater than one permit retries, and `max_attempts=0` is invalid.
+- **BREAKING:** Active-reset `max_attempts` must be a strictly positive, non-boolean integer. `max_attempts=1` selects a single-shot measure-and-conditional-pi reset with no `while_` retry loop; values greater than one permit retries, and `max_attempts=0` is invalid (#138).
 
 ### Fixed
 
-- Fixed TWPA pump initialization being skipped in subsequent QUA programs due to process-global deduplication state ([#122](https://github.com/qua-platform/quam-builder/issues/122)).
-- Restored `AnyQuamQD` type alias (`Union[BaseQuamQD, LossDiVincenzoQuam]`) in `architecture.quantum_dots.qpu`, fixing imports used by `qualibration-libs`.
+- Fixed TWPA pump initialization being skipped in subsequent QUA programs due to process-global deduplication state ([#122](https://github.com/qua-platform/quam-builder/issues/122)) (#137).
+- Restored `AnyQuamQD` type alias (`Union[BaseQuamQD, LossDiVincenzoQuam]`) in `architecture.quantum_dots.qpu`. Required by `qualibration-libs` (`qualibration_libs/parameters/experiment.py`) (#142).
 - `add_default_transmon_pair_macros` now passes `flux_pulse_qubit="const"` (was `flux_pulse_control="const"`) to `CZGate`, matching the field rename introduced in v0.4.0 and aligning with the `"const"` pulse added to every `FluxTunableTransmon` Z line by `add_default_transmon_pulses`.
-- Applied black formatting across the entire repo.
+- Applied black formatting across the entire repo (#128).
 
 ## [0.4.0] - 2026-05-26
 
@@ -108,7 +112,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Builder functions for the general QUAM wiring.
 - Builder functions for Transmons.
 
-[Unreleased]: https://github.com/qua-platform/quam-builder/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/qua-platform/quam-builder/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/qua-platform/quam-builder/releases/tag/v0.5.0
 [0.4.0]: https://github.com/qua-platform/quam-builder/releases/tag/v0.4.0
 [0.3.0]: https://github.com/qua-platform/quam-builder/releases/tag/v0.3.0
 [0.2.0]: https://github.com/qua-platform/quam-builder/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quam-builder"
-version = "0.4.0"
+version = "0.5.0"
 description = "A Python tool designed to programmatically construct QUAM (Quantum Abstract Machine) configurations for the Quantum Orchestration Platform (QOP)."
 readme = "README.md"
 authors = [{ name = "Theo Laudat", email = "theo@quantum-machines.co" }]
@@ -130,7 +130,7 @@ max-line-length = 120
 # -----------------------------
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.1.0"
+version = "0.5.0"
 tag_format = "v$version"
 version_files = ["pyproject.toml:version"]
 update_changelog_on_bump = true


### PR DESCRIPTION
## Description

Release preparation for **quam-builder v0.5.0** (same pattern as #118 for v0.4.0).

- Bump `version` to `0.5.0` in `pyproject.toml`
- Sync `[tool.commitizen] version` to `0.5.0`
- Move `[Unreleased]` changelog notes into `## [0.5.0] - 2026-08-19`
- Update changelog compare/release links for `v0.5.0`

No functional code changes in this PR — version and changelog only.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ✅ Test addition/update
- [ ] 🎨 Code style/formatting update

## Related Issues

Relates to #138, #142  
Follows release pattern from #118

## Checklist

### Code Quality

- [x] My code follows the project's style guidelines
- [ ] I have run `pre-commit` hooks and all checks pass (`pre-commit run --all-files`)
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

### Testing

- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally (`pytest`)
- [ ] I have tested my changes with the example scripts (if applicable)

### Documentation

- [x] I have updated the documentation (if needed)
- [ ] I have added docstrings to new functions/classes
- [x] I have updated the CHANGELOG.md (if applicable)
- [x] I have checked my code and corrected any misspellings

## Breaking Changes

This release **includes** breaking changes already merged to `main`:

- **Active-reset `max_attempts`:** must be a strictly positive, non-boolean integer. `max_attempts=1` = single-shot reset (no retry loop). `max_attempts=0` is **invalid** (#138).

## Testing Details

- `qualibration-libs` tests pass against local `quam-builder` `main` (`uv run pytest tests/ -v` — 39 passed)
- `quam-builder` tests pass locally (`uv run pytest tests/ -v`)
- Python 3.11, macOS

## Screenshots/Examples

N/A — release bump only.

## Additional Context

**After merge:**
1. Tag `v0.5.0` on the merge commit

**0.5.0 highlights** (documented in CHANGELOG):
- Default single-qubit gate macros (#101)
- `DrachmaReadoutPulse` (#140)
- TWPA keepalive + init dedup fixes (#135, #137)
- Incremental add/remove QUAM helpers (#121)
- `AnyQuamQD` alias restored for `qualibration-libs` (#142)

## Reviewer Notes

Please confirm changelog completeness and version bump only (no stray code changes). Tag/release to follow after merge.